### PR TITLE
feat: TODO 트리/그룹 상세 태그 placeholder 해소

### DIFF
--- a/lib/features/todo/presentation/pages/todo_group_detail_page.dart
+++ b/lib/features/todo/presentation/pages/todo_group_detail_page.dart
@@ -411,7 +411,7 @@ class TodoGroupDetailPage extends ConsumerWidget {
       destructive: true,
     );
 
-    if (confirmed == true && context.mounted) {
+    if (confirmed && context.mounted) {
       try {
         await ref.read(tagMutationsProvider.notifier).deleteGroup(group.id);
 

--- a/lib/features/todo/presentation/pages/todo_group_detail_page.dart
+++ b/lib/features/todo/presentation/pages/todo_group_detail_page.dart
@@ -5,8 +5,10 @@ import 'package:momeet/router.dart';
 import 'package:momeet/shared/api/rest/export.dart';
 import 'package:momeet/features/todo/presentation/providers/todo_provider.dart';
 import 'package:momeet/features/tag/presentation/providers/tag_providers.dart';
+import 'package:momeet/features/tag/presentation/widgets/tag_group_form_sheet.dart';
 import 'package:momeet/features/todo/presentation/widgets/todo_tree_tile.dart';
 import 'package:momeet/features/todo/presentation/widgets/todo_form_sheet.dart';
+import 'package:momeet/shared/widgets/confirm_dialog.dart';
 import 'package:momeet/core/utils/color_utils.dart';
 
 /// Todo 그룹 상세 페이지
@@ -35,7 +37,7 @@ class TodoGroupDetailPage extends ConsumerWidget {
           CustomScrollView(
             slivers: [
               // AppBar with group info
-              _buildAppBar(context, theme, groupAsync),
+              _buildAppBar(context, ref, theme, groupAsync),
 
               // Todo list content
               todoTreeAsync.when(
@@ -71,6 +73,7 @@ class TodoGroupDetailPage extends ConsumerWidget {
   /// 그룹 정보가 포함된 AppBar
   Widget _buildAppBar(
     BuildContext context,
+    WidgetRef ref,
     ThemeData theme,
     AsyncValue<List<TagGroupRead>> groupAsync,
   ) {
@@ -95,7 +98,7 @@ class TodoGroupDetailPage extends ConsumerWidget {
             IconButton(
               icon: const Icon(Icons.settings),
               tooltip: '그룹 설정',
-              onPressed: () => _showGroupSettings(context),
+              onPressed: () => _showGroupSettings(context, ref, group),
             ),
           ],
           flexibleSpace: FlexibleSpaceBar(
@@ -343,12 +346,17 @@ class TodoGroupDetailPage extends ConsumerWidget {
   }
 
   /// 그룹 설정 다이얼로그
-  void _showGroupSettings(BuildContext context) {
-    // TODO: 그룹 설정 (수정/삭제) 구현
+  void _showGroupSettings(
+    BuildContext context,
+    WidgetRef ref,
+    TagGroupRead? group,
+  ) {
+    if (group == null) return;
+
     showModalBottomSheet(
       context: context,
       useRootNavigator: true,
-      builder: (context) => Container(
+      builder: (sheetContext) => Container(
         padding: const EdgeInsets.all(16),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -357,9 +365,18 @@ class TodoGroupDetailPage extends ConsumerWidget {
               leading: const Icon(Icons.edit),
               title: const Text('그룹 수정'),
               onTap: () {
-                Navigator.pop(context);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('그룹 수정 기능이 곧 구현됩니다!')),
+                Navigator.pop(sheetContext);
+                showTagGroupFormSheet(
+                  context,
+                  tagGroup: TagGroupReadWithTags(
+                    id: group.id,
+                    name: group.name,
+                    color: group.color,
+                    createdAt: group.createdAt,
+                    updatedAt: group.updatedAt,
+                    description: group.description,
+                    goalRatios: group.goalRatios,
+                  ),
                 );
               },
             ),
@@ -367,16 +384,57 @@ class TodoGroupDetailPage extends ConsumerWidget {
               leading: const Icon(Icons.delete, color: Colors.red),
               title: const Text('그룹 삭제', style: TextStyle(color: Colors.red)),
               onTap: () {
-                Navigator.pop(context);
-                // TODO: 삭제 확인 다이얼로그
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('그룹 삭제 기능이 곧 구현됩니다!')),
-                );
+                Navigator.pop(sheetContext);
+                _showDeleteGroupDialog(context, ref, group);
               },
             ),
           ],
         ),
       ),
     );
+  }
+
+  /// 그룹 삭제 확인 다이얼로그
+  Future<void> _showDeleteGroupDialog(
+    BuildContext context,
+    WidgetRef ref,
+    TagGroupRead group,
+  ) async {
+    final confirmed = await showConfirmDialog(
+      context,
+      title: '그룹 삭제',
+      content:
+          '${group.name} 그룹을 삭제하시겠습니까?\n'
+          '이 작업은 되돌릴 수 없습니다.\n'
+          '그룹에 포함된 모든 태그도 함께 삭제됩니다.',
+      confirmText: '삭제',
+      destructive: true,
+    );
+
+    if (confirmed == true && context.mounted) {
+      try {
+        await ref.read(tagMutationsProvider.notifier).deleteGroup(group.id);
+
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('${group.name} 그룹이 삭제되었습니다'),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+          context.go(AppRoute.todo.path);
+        }
+      } catch (error) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('그룹 삭제에 실패했습니다: $error'),
+              backgroundColor: Colors.red,
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        }
+      }
+    }
   }
 }

--- a/lib/features/todo/presentation/pages/todo_group_detail_page.dart
+++ b/lib/features/todo/presentation/pages/todo_group_detail_page.dart
@@ -95,11 +95,12 @@ class TodoGroupDetailPage extends ConsumerWidget {
             onPressed: () => context.go(AppRoute.todo.path),
           ),
           actions: [
-            IconButton(
-              icon: const Icon(Icons.settings),
-              tooltip: '그룹 설정',
-              onPressed: () => _showGroupSettings(context, ref, group),
-            ),
+            if (group != null)
+              IconButton(
+                icon: const Icon(Icons.settings),
+                tooltip: '그룹 설정',
+                onPressed: () => _showGroupSettings(context, ref, group),
+              ),
           ],
           flexibleSpace: FlexibleSpaceBar(
             title: Text(
@@ -349,10 +350,8 @@ class TodoGroupDetailPage extends ConsumerWidget {
   void _showGroupSettings(
     BuildContext context,
     WidgetRef ref,
-    TagGroupRead? group,
+    TagGroupRead group,
   ) {
-    if (group == null) return;
-
     showModalBottomSheet(
       context: context,
       useRootNavigator: true,

--- a/lib/features/todo/presentation/widgets/tag_tree_list_view.dart
+++ b/lib/features/todo/presentation/widgets/tag_tree_list_view.dart
@@ -4,11 +4,11 @@ import 'package:momeet/shared/api/rest/export.dart';
 import 'package:momeet/features/todo/presentation/providers/tag_providers.dart';
 import 'package:momeet/features/tag/presentation/widgets/tag_form_sheet.dart';
 import 'package:momeet/shared/widgets/confirm_dialog.dart';
+import 'package:momeet/core/utils/color_utils.dart';
 
 /// 태그 트리 리스트 뷰
 ///
-/// 태그 그룹을 ExpansionTile로 표시하고,
-/// 태그는 드래그앤드롭으로 그룹 간 이동이 가능합니다.
+/// ��그 그룹을 ExpansionTile로 표시합니다.
 class TagTreeListView extends ConsumerWidget {
   const TagTreeListView({super.key});
 
@@ -91,280 +91,141 @@ class TagGroupExpansionTile extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final groupColor = _parseColor(group.color);
+    final groupColor = HexColor.fromHex(group.color);
 
-    return DragTarget<TagDragData>(
-      onAcceptWithDetails: (details) async {
-        final dragData = details.data;
-        if (dragData.groupId != group.id) {
-          // 다른 그룹으로 태그 이동
-          try {
-            await ref
-                .read(tagMutationsProvider.notifier)
-                .updateTag(
-                  dragData.tagId,
-                  TagUpdate(
-                    // groupId는 TagUpdate에 없으므로 다른 방법 사용 필요
-                    name: null, // 이름은 변경하지 않음
-                  ),
-                );
-
-            if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('태그 이동 기능이 곧 구현됩니다'),
-                  backgroundColor: theme.colorScheme.primary,
-                ),
-              );
-            }
-          } catch (error) {
-            if (context.mounted) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('태그 이동 실패: ${error.toString()}'),
-                  backgroundColor: theme.colorScheme.error,
-                ),
-              );
-            }
-          }
-        }
-      },
-      builder: (context, candidateData, rejectedData) {
-        final isReceivingDrag = candidateData.isNotEmpty;
-
-        return Card(
-          elevation: isReceivingDrag ? 4 : 1,
-          color: isReceivingDrag ? groupColor.withValues(alpha: 0.1) : null,
-          child: ExpansionTile(
-            key: PageStorageKey('tag_group_${group.id}'),
-            initiallyExpanded: isExpanded,
-            onExpansionChanged: onExpansionChanged,
-            leading: CircleAvatar(
-              backgroundColor: groupColor,
-              radius: 12,
-              child: Text(
-                group.tags.length.toString(),
-                style: TextStyle(
-                  color: theme.colorScheme.onPrimary,
-                  fontSize: 12,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
+    return Card(
+      elevation: 1,
+      child: ExpansionTile(
+        key: PageStorageKey('tag_group_${group.id}'),
+        initiallyExpanded: isExpanded,
+        onExpansionChanged: onExpansionChanged,
+        leading: CircleAvatar(
+          backgroundColor: groupColor,
+          radius: 12,
+          child: Text(
+            group.tags.length.toString(),
+            style: TextStyle(
+              color: theme.colorScheme.onPrimary,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
             ),
-            title: Text(
-              group.name,
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            subtitle: group.description != null
-                ? Text(
-                    group.description!,
-                    style: theme.textTheme.bodySmall,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  )
-                : null,
-            children: [
-              if (group.tags.isEmpty)
-                const ListTile(
-                  leading: Icon(Icons.info_outline),
-                  title: Text('태그가 없습니다'),
-                  subtitle: Text('새 태그를 추가해보세요'),
-                )
-              else
-                ...group.tags.map(
-                  (tag) => DraggableTagTile(tag: tag, groupColor: groupColor),
-                ),
-
-              // 태그 추가 버튼
-              ListTile(
-                leading: Icon(Icons.add, color: theme.colorScheme.primary),
-                title: Text(
-                  '태그 추가',
-                  style: TextStyle(
-                    color: theme.colorScheme.primary,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-                onTap: () => _showCreateTagDialog(context, ref, group.id),
-              ),
-            ],
           ),
-        );
-      },
+        ),
+        title: Text(
+          group.name,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        subtitle: group.description != null
+            ? Text(
+                group.description!,
+                style: theme.textTheme.bodySmall,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              )
+            : null,
+        children: [
+          if (group.tags.isEmpty)
+            const ListTile(
+              leading: Icon(Icons.info_outline),
+              title: Text('태그가 없습니다'),
+              subtitle: Text('새 태그를 추가해보세요'),
+            )
+          else
+            ...group.tags.map(
+              (tag) => TagTile(tag: tag, groupColor: groupColor),
+            ),
+
+          // 태그 추가 버튼
+          ListTile(
+            leading: Icon(Icons.add, color: theme.colorScheme.primary),
+            title: Text(
+              '태그 추가',
+              style: TextStyle(
+                color: theme.colorScheme.primary,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+            onTap: () => _showCreateTagDialog(context, group.id),
+          ),
+        ],
+      ),
     );
   }
 
-  /// 색상 문자열을 Color로 파싱
-  Color _parseColor(String colorString) {
-    try {
-      String hex = colorString.replaceAll('#', '');
-      if (hex.length == 6) {
-        hex = 'FF$hex';
-      }
-      return Color(int.parse(hex, radix: 16));
-    } catch (e) {
-      return Colors.grey; // 정적 fallback 색상
-    }
-  }
-
   /// 태그 생성 다이얼로그 표시
-  void _showCreateTagDialog(
-    BuildContext context,
-    WidgetRef ref,
-    String groupId,
-  ) {
+  void _showCreateTagDialog(BuildContext context, String groupId) {
     showTagFormSheet(context, defaultGroupId: groupId);
   }
 }
 
-/// 드래그 가능한 태그 타일
-class DraggableTagTile extends ConsumerWidget {
+/// 태그 타일
+class TagTile extends ConsumerWidget {
   final TagRead tag;
   final Color groupColor;
 
-  const DraggableTagTile({
-    super.key,
-    required this.tag,
-    required this.groupColor,
-  });
+  const TagTile({super.key, required this.tag, required this.groupColor});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final tagColor = _parseColor(tag.color);
+    final tagColor = HexColor.fromHex(tag.color);
 
-    return LongPressDraggable<TagDragData>(
-      data: TagDragData(tagId: tag.id, tagName: tag.name, groupId: tag.groupId),
-      feedback: Material(
-        elevation: 4,
-        borderRadius: BorderRadius.circular(8),
-        child: Container(
-          width: 250,
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: theme.colorScheme.surface,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: tagColor, width: 2),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 12,
-                height: 12,
-                decoration: BoxDecoration(
-                  color: tagColor,
-                  shape: BoxShape.circle,
-                ),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                tag.name,
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-            ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: ListTile(
+        leading: Container(
+          width: 12,
+          height: 12,
+          decoration: BoxDecoration(color: tagColor, shape: BoxShape.circle),
+        ),
+        title: Text(
+          tag.name,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            fontWeight: FontWeight.w500,
           ),
         ),
-      ),
-      childWhenDragging: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-        child: ListTile(
-          leading: Container(
-            width: 12,
-            height: 12,
-            decoration: BoxDecoration(
-              color: tagColor.withValues(alpha: 0.5),
-              shape: BoxShape.circle,
-            ),
-          ),
-          title: Text(
-            tag.name,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
-            ),
-          ),
-          subtitle: tag.description != null
-              ? Text(
-                  tag.description!,
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurface.withValues(alpha: 0.3),
-                  ),
-                )
-              : null,
-        ),
-      ),
-      child: Container(
-        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-        child: ListTile(
-          leading: Container(
-            width: 12,
-            height: 12,
-            decoration: BoxDecoration(color: tagColor, shape: BoxShape.circle),
-          ),
-          title: Text(
-            tag.name,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-          subtitle: tag.description != null
-              ? Text(
-                  tag.description!,
-                  style: theme.textTheme.bodySmall,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                )
-              : null,
-          trailing: PopupMenuButton(
-            itemBuilder: (context) => [
-              const PopupMenuItem(
-                value: 'edit',
-                child: ListTile(
-                  leading: Icon(Icons.edit),
-                  title: Text('수정'),
-                  contentPadding: EdgeInsets.zero,
-                ),
+        subtitle: tag.description != null
+            ? Text(
+                tag.description!,
+                style: theme.textTheme.bodySmall,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+              )
+            : null,
+        trailing: PopupMenuButton(
+          itemBuilder: (context) => [
+            const PopupMenuItem(
+              value: 'edit',
+              child: ListTile(
+                leading: Icon(Icons.edit),
+                title: Text('수정'),
+                contentPadding: EdgeInsets.zero,
               ),
-              const PopupMenuItem(
-                value: 'delete',
-                child: ListTile(
-                  leading: Icon(Icons.delete, color: Colors.red),
-                  title: Text('삭제', style: TextStyle(color: Colors.red)),
-                  contentPadding: EdgeInsets.zero,
-                ),
+            ),
+            const PopupMenuItem(
+              value: 'delete',
+              child: ListTile(
+                leading: Icon(Icons.delete, color: Colors.red),
+                title: Text('삭제', style: TextStyle(color: Colors.red)),
+                contentPadding: EdgeInsets.zero,
               ),
-            ],
-            onSelected: (value) async {
-              switch (value) {
-                case 'edit':
-                  showTagFormSheet(context, tag: tag);
-                  break;
-                case 'delete':
-                  await _showDeleteConfirmDialog(context, ref, tag);
-                  break;
-              }
-            },
-          ),
+            ),
+          ],
+          onSelected: (value) async {
+            switch (value) {
+              case 'edit':
+                showTagFormSheet(context, tag: tag);
+                break;
+              case 'delete':
+                await _showDeleteConfirmDialog(context, ref, tag);
+                break;
+            }
+          },
         ),
       ),
     );
-  }
-
-  /// 색상 문자열을 Color로 파싱
-  Color _parseColor(String colorString) {
-    try {
-      String hex = colorString.replaceAll('#', '');
-      if (hex.length == 6) {
-        hex = 'FF$hex';
-      }
-      return Color(int.parse(hex, radix: 16));
-    } catch (e) {
-      return Colors.grey; // 여기는 정적 함수이므로 유지
-    }
   }
 
   /// 삭제 확인 다이얼로그
@@ -406,17 +267,4 @@ class DraggableTagTile extends ConsumerWidget {
       }
     }
   }
-}
-
-/// 태그 드래그 데이터 클래스
-class TagDragData {
-  final String tagId;
-  final String tagName;
-  final String groupId;
-
-  const TagDragData({
-    required this.tagId,
-    required this.tagName,
-    required this.groupId,
-  });
 }

--- a/lib/features/todo/presentation/widgets/tag_tree_list_view.dart
+++ b/lib/features/todo/presentation/widgets/tag_tree_list_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:momeet/shared/api/rest/export.dart';
 import 'package:momeet/features/todo/presentation/providers/tag_providers.dart';
+import 'package:momeet/features/tag/presentation/widgets/tag_form_sheet.dart';
 import 'package:momeet/shared/widgets/confirm_dialog.dart';
 
 /// 태그 트리 리스트 뷰
@@ -214,15 +215,12 @@ class TagGroupExpansionTile extends ConsumerWidget {
     WidgetRef ref,
     String groupId,
   ) {
-    // TODO: 태그 생성 다이얼로그 구현
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('태그 생성 다이얼로그가 곧 구현됩니다')));
+    showTagFormSheet(context, defaultGroupId: groupId);
   }
 }
 
 /// 드래그 가능한 태그 타일
-class DraggableTagTile extends StatelessWidget {
+class DraggableTagTile extends ConsumerWidget {
   final TagRead tag;
   final Color groupColor;
 
@@ -233,7 +231,7 @@ class DraggableTagTile extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final tagColor = _parseColor(tag.color);
 
@@ -343,13 +341,10 @@ class DraggableTagTile extends StatelessWidget {
             onSelected: (value) async {
               switch (value) {
                 case 'edit':
-                  // TODO: 태그 수정 다이얼로그
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('태그 수정 기능이 곧 구현됩니다')),
-                  );
+                  showTagFormSheet(context, tag: tag);
                   break;
                 case 'delete':
-                  await _showDeleteConfirmDialog(context, tag);
+                  await _showDeleteConfirmDialog(context, ref, tag);
                   break;
               }
             },
@@ -375,6 +370,7 @@ class DraggableTagTile extends StatelessWidget {
   /// 삭제 확인 다이얼로그
   Future<void> _showDeleteConfirmDialog(
     BuildContext context,
+    WidgetRef ref,
     TagRead tag,
   ) async {
     final confirmed = await showConfirmDialog(
@@ -387,10 +383,28 @@ class DraggableTagTile extends StatelessWidget {
 
     if (!confirmed || !context.mounted) return;
 
-    // TODO: 삭제 로직 구현
-    ScaffoldMessenger.of(
-      context,
-    ).showSnackBar(const SnackBar(content: Text('태그 삭제 기능이 곧 구현됩니다')));
+    try {
+      await ref.read(tagMutationsProvider.notifier).deleteTag(tag.id);
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('${tag.name} 태그가 삭제되었습니다'),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } catch (error) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('태그 삭제에 실패했습니다: $error'),
+            backgroundColor: Colors.red,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    }
   }
 }
 

--- a/lib/features/todo/presentation/widgets/tag_tree_list_view.dart
+++ b/lib/features/todo/presentation/widgets/tag_tree_list_view.dart
@@ -8,7 +8,7 @@ import 'package:momeet/core/utils/color_utils.dart';
 
 /// 태그 트리 리스트 뷰
 ///
-/// ��그 그룹을 ExpansionTile로 표시합니다.
+/// 태그 그룹을 ExpansionTile로 표시합니다.
 class TagTreeListView extends ConsumerWidget {
   const TagTreeListView({super.key});
 

--- a/test/features/todo/presentation/widgets/tag_tree_list_view_test.dart
+++ b/test/features/todo/presentation/widgets/tag_tree_list_view_test.dart
@@ -45,13 +45,13 @@ void main() {
       overrides: [tagsApiProvider.overrideWithValue(mockTagsClient)],
       child: MaterialApp(
         home: Scaffold(
-          body: DraggableTagTile(tag: tag, groupColor: Colors.blue),
+          body: TagTile(tag: tag, groupColor: Colors.blue),
         ),
       ),
     );
   }
 
-  group('DraggableTagTile UI 렌더링', () {
+  group('TagTile UI 렌더링', () {
     testWidgets('태그 이름과 PopupMenuButton이 표시된다', (tester) async {
       await tester.pumpWidget(buildTestWidget(tag: testTag));
 
@@ -75,7 +75,7 @@ void main() {
     });
   });
 
-  group('DraggableTagTile 삭제 확인 다이얼로그', () {
+  group('TagTile 삭제 확인 다이얼로그', () {
     testWidgets('삭제 메뉴 선택 시 확인 다이얼로그가 표시된다', (tester) async {
       await tester.pumpWidget(buildTestWidget(tag: testTag));
 
@@ -165,7 +165,7 @@ void main() {
     });
   });
 
-  group('DraggableTagTile 수정', () {
+  group('TagTile 수정', () {
     testWidgets('수정 메뉴 선택 시 태그 폼 시트가 표시된다', (tester) async {
       // TagFormSheet가 태그의 그룹 정보를 조회하므로 해당 그룹을 포함한 mock 데이터 필요
       when(

--- a/test/features/todo/presentation/widgets/tag_tree_list_view_test.dart
+++ b/test/features/todo/presentation/widgets/tag_tree_list_view_test.dart
@@ -1,10 +1,25 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:momeet/features/todo/presentation/widgets/tag_tree_list_view.dart';
 import 'package:momeet/shared/api/rest/export.dart';
+import 'package:momeet/shared/providers/api_providers.dart';
+
+class MockTagsClient extends Mock implements TagsClient {}
+
+class FakeTagUpdate extends Fake implements TagUpdate {}
+
+class FakeTagCreate extends Fake implements TagCreate {}
 
 void main() {
   late TagRead testTag;
+  late MockTagsClient mockTagsClient;
+
+  setUpAll(() {
+    registerFallbackValue(FakeTagUpdate());
+    registerFallbackValue(FakeTagCreate());
+  });
 
   setUp(() {
     testTag = TagRead(
@@ -15,15 +30,50 @@ void main() {
       createdAt: DateTime(2025, 1, 1),
       updatedAt: DateTime(2025, 1, 1),
     );
+    mockTagsClient = MockTagsClient();
+
+    // 기본 mock: tagGroups 조회 (tagMutations가 invalidate 시 필요)
+    when(
+      () => mockTagsClient.readTagGroupsV1TagsGroupsGet(
+        options: any(named: 'options'),
+      ),
+    ).thenAnswer((_) async => <TagGroupReadWithTags>[]);
   });
 
   Widget buildTestWidget({required TagRead tag}) {
-    return MaterialApp(
-      home: Scaffold(
-        body: DraggableTagTile(tag: tag, groupColor: Colors.blue),
+    return ProviderScope(
+      overrides: [tagsApiProvider.overrideWithValue(mockTagsClient)],
+      child: MaterialApp(
+        home: Scaffold(
+          body: DraggableTagTile(tag: tag, groupColor: Colors.blue),
+        ),
       ),
     );
   }
+
+  group('DraggableTagTile UI 렌더링', () {
+    testWidgets('태그 이름과 PopupMenuButton이 표시된다', (tester) async {
+      await tester.pumpWidget(buildTestWidget(tag: testTag));
+
+      expect(find.text('테스트 태그'), findsOneWidget);
+      expect(find.byType(PopupMenuButton<String>), findsOneWidget);
+    });
+
+    testWidgets('설명이 있으면 표시된다', (tester) async {
+      final tagWithDesc = TagRead(
+        id: 'tag-2',
+        name: '설명 태그',
+        color: '#00FF00',
+        groupId: 'group-1',
+        description: '태그 설명입니다',
+        createdAt: DateTime(2025, 1, 1),
+        updatedAt: DateTime(2025, 1, 1),
+      );
+      await tester.pumpWidget(buildTestWidget(tag: tagWithDesc));
+
+      expect(find.text('태그 설명입니다'), findsOneWidget);
+    });
+  });
 
   group('DraggableTagTile 삭제 확인 다이얼로그', () {
     testWidgets('삭제 메뉴 선택 시 확인 다이얼로그가 표시된다', (tester) async {
@@ -44,7 +94,7 @@ void main() {
       expect(find.widgetWithText(FilledButton, '삭제'), findsOneWidget);
     });
 
-    testWidgets('다이얼로그에서 취소 시 SnackBar가 표시되지 않는다', (tester) async {
+    testWidgets('다이얼로그에서 취소 시 API가 호출되지 않는다', (tester) async {
       await tester.pumpWidget(buildTestWidget(tag: testTag));
 
       await tester.tap(find.byType(PopupMenuButton<String>));
@@ -56,10 +106,22 @@ void main() {
       await tester.tap(find.text('취소'));
       await tester.pumpAndSettle();
 
-      expect(find.text('태그 삭제 기능이 곧 구현됩니다'), findsNothing);
+      verifyNever(
+        () => mockTagsClient.deleteTagV1TagsTagIdDelete(
+          tagId: any(named: 'tagId'),
+          options: any(named: 'options'),
+        ),
+      );
     });
 
-    testWidgets('다이얼로그에서 삭제 확인 시 SnackBar가 표시된다', (tester) async {
+    testWidgets('삭제 확인 시 API가 호출되고 성공 SnackBar가 표시된다', (tester) async {
+      when(
+        () => mockTagsClient.deleteTagV1TagsTagIdDelete(
+          tagId: 'tag-1',
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) async {});
+
       await tester.pumpWidget(buildTestWidget(tag: testTag));
 
       await tester.tap(find.byType(PopupMenuButton<String>));
@@ -71,10 +133,23 @@ void main() {
       await tester.tap(find.widgetWithText(FilledButton, '삭제'));
       await tester.pumpAndSettle();
 
-      expect(find.text('태그 삭제 기능이 곧 구현됩니다'), findsOneWidget);
+      verify(
+        () => mockTagsClient.deleteTagV1TagsTagIdDelete(
+          tagId: 'tag-1',
+          options: any(named: 'options'),
+        ),
+      ).called(1);
+      expect(find.text('테스트 태그 태그가 삭제되었습니다'), findsOneWidget);
     });
 
-    testWidgets('다이얼로그가 닫힌 뒤에만 SnackBar가 표시된다 (await 동작 검증)', (tester) async {
+    testWidgets('삭제 실패 시 에러 SnackBar가 표시된다', (tester) async {
+      when(
+        () => mockTagsClient.deleteTagV1TagsTagIdDelete(
+          tagId: 'tag-1',
+          options: any(named: 'options'),
+        ),
+      ).thenThrow(Exception('서버 오류'));
+
       await tester.pumpWidget(buildTestWidget(tag: testTag));
 
       await tester.tap(find.byType(PopupMenuButton<String>));
@@ -83,14 +158,47 @@ void main() {
       await tester.tap(find.text('삭제'));
       await tester.pumpAndSettle();
 
-      expect(find.text('태그 삭제'), findsOneWidget);
-      expect(find.text('태그 삭제 기능이 곧 구현됩니다'), findsNothing);
-
       await tester.tap(find.widgetWithText(FilledButton, '삭제'));
       await tester.pumpAndSettle();
 
-      expect(find.text('태그 삭제'), findsNothing);
-      expect(find.text('태그 삭제 기능이 곧 구현됩니다'), findsOneWidget);
+      expect(find.textContaining('태그 삭제에 실패했습니다'), findsOneWidget);
+    });
+  });
+
+  group('DraggableTagTile 수정', () {
+    testWidgets('수정 메뉴 선택 시 태그 폼 시트가 표시된다', (tester) async {
+      // TagFormSheet가 태그의 그룹 정보를 조회하므로 해당 그룹을 포함한 mock 데이터 필요
+      when(
+        () => mockTagsClient.readTagGroupsV1TagsGroupsGet(
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer(
+        (_) async => [
+          TagGroupReadWithTags(
+            id: 'group-1',
+            name: '테스트 그룹',
+            color: '#3498DB',
+            createdAt: DateTime(2025, 1, 1),
+            updatedAt: DateTime(2025, 1, 1),
+            tags: [testTag],
+          ),
+        ],
+      );
+      when(
+        () => mockTagsClient.readTagsV1TagsGet(options: any(named: 'options')),
+      ).thenAnswer((_) async => [testTag]);
+
+      await tester.pumpWidget(buildTestWidget(tag: testTag));
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('수정'));
+      await tester.pumpAndSettle();
+
+      // TagFormSheet가 BottomSheet로 표시되고 '태그 수정' 타이틀이 보이는지 확인
+      expect(find.byType(BottomSheet), findsOneWidget);
+      expect(find.text('태그 수정'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Change Log
- TODO 그룹 상세: 그룹 수정(PATCH) — `showTagGroupFormSheet` 연결, 그룹 삭제(DELETE) — 확인 다이얼로그 + API 호출
- TODO 트리: 태그 생성(POST) — `showTagFormSheet` 연결, 태그 수정(PATCH) — PopupMenu → 폼 시트, 태그 삭제(DELETE) — 확인 다이얼로그 + API 호출
- 미지원 드래그&드롭 태그 이동 코드 제거 (`DragTarget`, `LongPressDraggable`, `TagDragData`)
- `DraggableTagTile` → `TagTile`로 단순화
- 중복 `_parseColor`를 기존 `HexColor.fromHex` 유틸리티로 통일
- `_showGroupSettings`의 nullable `group?` → non-nullable로 변경, call site에서 null guard

## Issue Number
- close #39

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] Code generation runs cleanly (`fvm dart run build_runner build --delete-conflicting-outputs`)
- [x] `fvm flutter analyze` passes with no issues.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new widget, screen, or provider).
- [ ] This PR is a breaking change (e.g. model or API client changes).