### PR TITLE
chore: 자동 버전 태깅 및 릴리스 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -3,6 +3,10 @@ name: Deploy Production
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - '*.md'
+      - '.github/workflows/release.yml'
 
 concurrency:
   group: production-deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Tag & Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate version
+        id: version
+        run: |
+          VERSION="v$(date +'%Y.%m.%d')-$(git rev-parse --short HEAD)"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Update CHANGELOG [Unreleased] → version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          REPO_URL: https://github.com/${{ github.repository }}
+        run: |
+          TODAY=$(date +'%Y-%m-%d')
+
+          # [Unreleased] 섹션에 실제 내용이 있을 때만 치환
+          if grep -q "^## \[Unreleased\]" CHANGELOG.md && \
+             ! grep -q "_No unreleased changes._" CHANGELOG.md; then
+
+            # [Unreleased] → [version] - date
+            sed -i "s/^## \[Unreleased\]/## [${VERSION}] - ${TODAY}/" CHANGELOG.md
+
+            # 새 [Unreleased] 섹션을 상단에 추가
+            sed -i "/^## \[${VERSION}\]/i ## [Unreleased]\n\n_No unreleased changes._\n\n---\n" CHANGELOG.md
+
+            # 하단 reference link 갱신
+            PREV_TAG=$(sed -n 's/^\[Unreleased\]: .*compare\/\(.*\)\.\.\.HEAD$/\1/p' CHANGELOG.md)
+            sed -i "s|^\[Unreleased\]: .*|[Unreleased]: ${REPO_URL}/compare/${VERSION}...HEAD|" CHANGELOG.md
+            sed -i "/^\[Unreleased\]: /a [${VERSION}]: ${REPO_URL}/compare/${PREV_TAG}...${VERSION}" CHANGELOG.md
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add CHANGELOG.md
+            git commit -m "chore: update CHANGELOG for ${VERSION}"
+            git push
+          fi
+
+      - name: Create git tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git tag "$VERSION"
+          git push origin "$VERSION"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if gh release view "$VERSION" &>/dev/null; then
+            exit 0
+          fi
+
+          gh release create "$VERSION" \
+            --generate-notes \
+            --title "Release $VERSION"

--- a/.gitignore
+++ b/.gitignore
@@ -460,3 +460,4 @@ lefthook-local.yml
 .vercel
 
 .*/*
+!.github/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Todo 수정 시 `parent_id` 보존하여 트리 관계 유지
 - Todo, Schedule, TagGroup 수정 폼에서 description 비우기 반영
 
+#### Landing & Loading
+- landing → 앱 전환 시 로딩 화면 탈출 불가 버그 수정
+- 랜딩 페이지 앵커 클릭 시 경로 전환 버그 수정
+- 모바일 가로 스크롤 및 배경 blob 잘림 수정
+- Flutter 부트스트랩 `hostElement` 무시 및 아이콘 폰트 깨짐 수정
+- 인증 유저 루트 진입 시 랜딩 대신 앱으로 직행하도록 수정
+
+#### API
+- API 모델에서 제거된 `isTodoGroup` 필드 참조 제거
+
 ### Added
+
+#### Landing & Loading
+- Flutter 로딩 중 표시할 정적 랜딩 페이지 추가 (`web/landing/`)
+- 랜딩/로딩 페이지 분리 및 Flutter 부트스트랩 개선
+- 생산성 아이콘 SVG 순환 애니메이션 로딩 화면
+- 시뮬레이션 프로그레스 바 추가
+- 앱 아이콘/프리뷰 이미지 및 noscript 대응
+- 미인증 루트 접근 시 `/landing` 리다이렉트
+
+#### API
+- `openapi.json` 기반 REST 클라이언트 재생성
+- `VisibilityLevel`, `VisibilityRead`, `VisibilityUpdate`, `ResourceType` 등 신규 모델 추가
+- `MeetingCreate`, `MeetingUpdate` 등 미팅 관련 모델 추가
 
 #### Core Infrastructure
 - Flutter project setup with FVM (stable channel)


### PR DESCRIPTION
## Summary

- `release.yml` 추가: main push 시 `v2026.04.04-abc1234` 형식으로 버전 태그 생성, CHANGELOG `[Unreleased]` 자동 치환, GitHub Release 생성
- `deploy-production.yml` 수정: CHANGELOG/md 변경 시 불필요한 재배포 방지 (`paths-ignore`)
- `.gitignore` 수정: `.*/*` 패턴이 `.github/` 디렉토리를 무시하던 문제 해결

백엔드의 릴리스 워크플로우를 참고하되 Docker 관련 부분을 제거하고 프론트엔드 프로세스에 맞게 구성했습니다.

## Test plan

- [ ] `release.yml` 문법 검증 (actionlint 등)
- [ ] dev → main 머지 후 Release, Tag, CHANGELOG 자동 업데이트 확인
- [ ] CHANGELOG만 변경된 커밋이 deploy-production을 트리거하지 않는지 확인