### PR TITLE
feat: TODO 트리 타이머 placeholder 해소

### DIFF
--- a/lib/features/timer/presentation/providers/timer_providers.dart
+++ b/lib/features/timer/presentation/providers/timer_providers.dart
@@ -162,6 +162,8 @@ Stream<Duration> timerTicker(Ref ref) async* {
 // Timer Controller (Mutation)
 // ============================================================
 
+const _wsNotConnectedError = 'WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.';
+
 /// 타이머 제어 로직
 ///
 /// 타이머 시작/정지 등의 CUD 작업을 담당합니다.
@@ -194,7 +196,7 @@ class TimerController extends _$TimerController {
         state = const AsyncValue.data(null);
         return;
       }
-      throw Exception('WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.');
+      throw Exception(_wsNotConnectedError);
     } catch (error, stackTrace) {
       state = AsyncValue.error(error, stackTrace);
       rethrow;
@@ -229,7 +231,7 @@ class TimerController extends _$TimerController {
         return;
       }
 
-      throw Exception('WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.');
+      throw Exception(_wsNotConnectedError);
     } catch (error, stackTrace) {
       state = AsyncValue.error(error, stackTrace);
       rethrow;
@@ -266,7 +268,7 @@ class TimerController extends _$TimerController {
         return;
       }
 
-      throw Exception('WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.');
+      throw Exception(_wsNotConnectedError);
     } catch (error, stackTrace) {
       state = AsyncValue.error(error, stackTrace);
       rethrow;
@@ -303,7 +305,7 @@ class TimerController extends _$TimerController {
         return;
       }
 
-      throw Exception('WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.');
+      throw Exception(_wsNotConnectedError);
     } catch (error, stackTrace) {
       state = AsyncValue.error(error, stackTrace);
       rethrow;

--- a/lib/features/timer/presentation/providers/timer_providers.dart
+++ b/lib/features/timer/presentation/providers/timer_providers.dart
@@ -229,10 +229,7 @@ class TimerController extends _$TimerController {
         return;
       }
 
-      final repository = ref.read(timerRepositoryProvider);
-      await repository.updateTimer(id, const TimerUpdate());
-      state = const AsyncValue.data(null);
-      ref.invalidate(timerHistoryProvider);
+      throw Exception('WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.');
     } catch (error, stackTrace) {
       state = AsyncValue.error(error, stackTrace);
       rethrow;
@@ -269,9 +266,7 @@ class TimerController extends _$TimerController {
         return;
       }
 
-      final repository = ref.read(timerRepositoryProvider);
-      await repository.updateTimer(id, const TimerUpdate());
-      state = const AsyncValue.data(null);
+      throw Exception('WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.');
     } catch (error, stackTrace) {
       state = AsyncValue.error(error, stackTrace);
       rethrow;
@@ -308,9 +303,7 @@ class TimerController extends _$TimerController {
         return;
       }
 
-      final repository = ref.read(timerRepositoryProvider);
-      await repository.updateTimer(id, const TimerUpdate());
-      state = const AsyncValue.data(null);
+      throw Exception('WebSocket에 연결되어 있지 않습니다. 로그인 후 다시 시도하세요.');
     } catch (error, stackTrace) {
       state = AsyncValue.error(error, stackTrace);
       rethrow;

--- a/lib/features/todo/presentation/providers/timer_providers.dart
+++ b/lib/features/todo/presentation/providers/timer_providers.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:momeet/shared/providers/api_providers.dart';
 import 'package:momeet/shared/api/rest/export.dart';
+import 'package:momeet/features/timer/presentation/providers/timer_providers.dart'
+    as timer_feature;
 import 'package:momeet/features/todo/presentation/providers/todo_provider.dart';
 import 'package:momeet/features/todo/presentation/utils/todo_tree_builder.dart';
 
@@ -73,12 +74,17 @@ Future<TodoTimerAggregation?> todoTimerAggregation(
 // ============================================================
 
 /// 활성 타이머 실시간 스트림
+///
+/// Timer feature의 [timer_feature.activeTimerProvider](WS 기반)를 watch하여
+/// WS 이벤트 수신 시 스트림이 재시작됩니다.
 @riverpod
 Stream<Map<String, ActiveTimerState>> activeTimerStream(Ref ref) async* {
-  // 처음에는 현재 활성 타이머 조회
+  // WS 이벤트를 변경 신호로 watch — 이벤트마다 스트림 재시작
+  ref.watch(timer_feature.activeTimerProvider);
+
   final activeTimers = await ref.watch(activeTimersProvider.future);
 
-  yield* Stream.periodic(const Duration(seconds: 1), (count) {
+  yield* Stream.periodic(const Duration(seconds: 1), (_) {
     final now = DateTime.now();
     final activeStates = <String, ActiveTimerState>{};
 
@@ -109,20 +115,7 @@ Stream<Map<String, ActiveTimerState>> activeTimerStream(Ref ref) async* {
       }
     }
 
-    return MapEntry(count, activeStates);
-  }).asyncMap((entry) async {
-    final count = entry.key;
-    final states = entry.value;
-
-    // 상태가 변경되면 활성 타이머 다시 조회 (10초마다)
-    if (count % 10 == 0) {
-      try {
-        final _ = await ref.refresh(activeTimersProvider.future);
-      } catch (error) {
-        debugPrint('활성 타이머 재조회 실패: $error');
-      }
-    }
-    return states;
+    return activeStates;
   });
 }
 

--- a/lib/features/todo/presentation/providers/timer_providers.dart
+++ b/lib/features/todo/presentation/providers/timer_providers.dart
@@ -127,62 +127,6 @@ Stream<Map<String, ActiveTimerState>> activeTimerStream(Ref ref) async* {
 }
 
 // ============================================================
-// Timer Mutation Provider
-// ============================================================
-
-/// 타이머 관련 CUD 작업
-@riverpod
-class TimerMutations extends _$TimerMutations {
-  @override
-  FutureOr<void> build() {}
-
-  /// 타이머 업데이트 (현재 사용 가능한 유일한 메서드)
-  Future<TimerRead> updateTimer(String timerId, TimerUpdate data) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(timersApiProvider);
-      final result = await api.updateTimerV1TimersTimerIdPatch(
-        timerId: timerId,
-        body: data,
-      );
-
-      state = const AsyncValue.data(null);
-
-      // 관련 데이터 새로고침
-      ref.invalidate(timersProvider());
-      ref.invalidate(activeTimersProvider);
-      ref.invalidate(todoTimerAggregationsProvider);
-
-      return result;
-    } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
-      rethrow;
-    }
-  }
-
-  /// 타이머 삭제
-  Future<void> deleteTimer(String timerId) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(timersApiProvider);
-      await api.deleteTimerV1TimersTimerIdDelete(timerId: timerId);
-
-      state = const AsyncValue.data(null);
-
-      // 관련 데이터 새로고침
-      ref.invalidate(timersProvider());
-      ref.invalidate(activeTimersProvider);
-      ref.invalidate(todoTimerAggregationsProvider);
-    } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
-      rethrow;
-    }
-  }
-}
-
-// ============================================================
 // Helper Classes & Functions
 // ============================================================
 

--- a/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
+++ b/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
@@ -314,6 +314,7 @@ class TimerControlButtons extends ConsumerWidget {
       await ref
           .read(timerControllerProvider.notifier)
           .startTimer(relatedTodoId: todoId);
+      ref.invalidate(activeTimersProvider);
       ref.invalidate(todoTimerAggregationsProvider);
     } catch (error) {
       if (context.mounted) {
@@ -341,6 +342,7 @@ class TimerControlButtons extends ConsumerWidget {
       } else {
         await notifier.resumeTimer(timerId: timerState.timerId);
       }
+      ref.invalidate(activeTimersProvider);
       ref.invalidate(todoTimerAggregationsProvider);
     } catch (error) {
       if (context.mounted) {
@@ -373,6 +375,7 @@ class TimerControlButtons extends ConsumerWidget {
         await ref
             .read(timerControllerProvider.notifier)
             .stopTimer(timerId: timerState.timerId);
+        ref.invalidate(activeTimersProvider);
         ref.invalidate(todoTimerAggregationsProvider);
       } catch (error) {
         if (context.mounted) {

--- a/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
+++ b/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:momeet/features/timer/presentation/providers/timer_providers.dart';
 import 'package:momeet/features/todo/presentation/providers/timer_providers.dart';
 import 'package:momeet/features/todo/presentation/utils/todo_tree_builder.dart';
 import 'package:momeet/features/todo/presentation/utils/todo_actions.dart';
@@ -251,7 +252,7 @@ class TimerControlButtons extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final mutations = ref.watch(timerMutationsProvider);
+    final timerController = ref.watch(timerControllerProvider);
 
     final hasActiveTimer = activeTimerState != null;
     final isRunning = activeTimerState?.isRunning ?? false;
@@ -261,7 +262,7 @@ class TimerControlButtons extends ConsumerWidget {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.end,
         children: [
-          if (mutations.isLoading)
+          if (timerController.isLoading)
             const SizedBox(
               width: 20,
               height: 20,
@@ -276,7 +277,8 @@ class TimerControlButtons extends ConsumerWidget {
                     ? theme.colorScheme.error
                     : theme.colorScheme.primary,
               ),
-              onPressed: () => _handleTimerToggle(ref, activeTimerState!),
+              onPressed: () =>
+                  _handleTimerToggle(context, ref, activeTimerState!),
               tooltip: isRunning ? '일시정지' : '재개',
               constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
               padding: EdgeInsets.zero,
@@ -308,10 +310,9 @@ class TimerControlButtons extends ConsumerWidget {
   /// 타이머 시작
   Future<void> _handleTimerStart(BuildContext context, WidgetRef ref) async {
     try {
-      // 현재는 타이머 생성 API가 없으므로 placeholder 구현
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('타이머 기능이 곧 구현됩니다')));
+      await ref
+          .read(timerControllerProvider.notifier)
+          .startTimer(relatedTodoId: todoId);
     } catch (error) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -326,15 +327,26 @@ class TimerControlButtons extends ConsumerWidget {
 
   /// 타이머 일시정지/재개 토글
   Future<void> _handleTimerToggle(
+    BuildContext context,
     WidgetRef ref,
     ActiveTimerState timerState,
   ) async {
     try {
-      // 현재는 타이머 제어 API가 없으므로 placeholder 구현
-      debugPrint('타이머 토글: ${timerState.timerId}');
+      final notifier = ref.read(timerControllerProvider.notifier);
+      if (timerState.isRunning) {
+        await notifier.pauseTimer(timerId: timerState.timerId);
+      } else {
+        await notifier.resumeTimer(timerId: timerState.timerId);
+      }
     } catch (error) {
-      // 에러는 mutations provider의 state에서 처리됨
-      debugPrint('타이머 토글 실패: $error');
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('타이머 토글 실패: $error'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
     }
   }
 
@@ -353,14 +365,9 @@ class TimerControlButtons extends ConsumerWidget {
 
     if (confirmed) {
       try {
-        // 현재는 타이머 정지 API가 없으므로 placeholder 구현
-        debugPrint('타이머 정지: ${timerState.timerId}');
-
-        if (context.mounted) {
-          ScaffoldMessenger.of(
-            context,
-          ).showSnackBar(const SnackBar(content: Text('타이머 정지 기능이 곧 구현됩니다')));
-        }
+        await ref
+            .read(timerControllerProvider.notifier)
+            .stopTimer(timerId: timerState.timerId);
       } catch (error) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
+++ b/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
@@ -309,10 +309,13 @@ class TimerControlButtons extends ConsumerWidget {
 
   /// 타이머 시작
   Future<void> _handleTimerStart(BuildContext context, WidgetRef ref) async {
+    if (ref.read(timerControllerProvider).isLoading) return;
     try {
       await ref
           .read(timerControllerProvider.notifier)
           .startTimer(relatedTodoId: todoId);
+      ref.invalidate(activeTimersProvider);
+      ref.invalidate(todoTimerAggregationsProvider);
     } catch (error) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -331,6 +334,7 @@ class TimerControlButtons extends ConsumerWidget {
     WidgetRef ref,
     ActiveTimerState timerState,
   ) async {
+    if (ref.read(timerControllerProvider).isLoading) return;
     try {
       final notifier = ref.read(timerControllerProvider.notifier);
       if (timerState.isRunning) {
@@ -338,6 +342,8 @@ class TimerControlButtons extends ConsumerWidget {
       } else {
         await notifier.resumeTimer(timerId: timerState.timerId);
       }
+      ref.invalidate(activeTimersProvider);
+      ref.invalidate(todoTimerAggregationsProvider);
     } catch (error) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -356,6 +362,7 @@ class TimerControlButtons extends ConsumerWidget {
     WidgetRef ref,
     ActiveTimerState timerState,
   ) async {
+    if (ref.read(timerControllerProvider).isLoading) return;
     final confirmed = await showConfirmDialog(
       context,
       title: '타이머 정지',
@@ -368,6 +375,8 @@ class TimerControlButtons extends ConsumerWidget {
         await ref
             .read(timerControllerProvider.notifier)
             .stopTimer(timerId: timerState.timerId);
+        ref.invalidate(activeTimersProvider);
+        ref.invalidate(todoTimerAggregationsProvider);
       } catch (error) {
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
+++ b/lib/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart
@@ -314,7 +314,6 @@ class TimerControlButtons extends ConsumerWidget {
       await ref
           .read(timerControllerProvider.notifier)
           .startTimer(relatedTodoId: todoId);
-      ref.invalidate(activeTimersProvider);
       ref.invalidate(todoTimerAggregationsProvider);
     } catch (error) {
       if (context.mounted) {
@@ -342,7 +341,6 @@ class TimerControlButtons extends ConsumerWidget {
       } else {
         await notifier.resumeTimer(timerId: timerState.timerId);
       }
-      ref.invalidate(activeTimersProvider);
       ref.invalidate(todoTimerAggregationsProvider);
     } catch (error) {
       if (context.mounted) {
@@ -375,7 +373,6 @@ class TimerControlButtons extends ConsumerWidget {
         await ref
             .read(timerControllerProvider.notifier)
             .stopTimer(timerId: timerState.timerId);
-        ref.invalidate(activeTimersProvider);
         ref.invalidate(todoTimerAggregationsProvider);
       } catch (error) {
         if (context.mounted) {

--- a/test/features/todo/presentation/widgets/timer_control_buttons_test.dart
+++ b/test/features/todo/presentation/widgets/timer_control_buttons_test.dart
@@ -1,0 +1,315 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:momeet/features/timer/presentation/providers/timer_providers.dart';
+import 'package:momeet/features/todo/presentation/providers/timer_providers.dart';
+import 'package:momeet/features/todo/presentation/widgets/todo_tree_tile_with_timer.dart';
+import 'package:momeet/shared/api/rest/export.dart';
+
+import '../../../../helpers/pump_app.dart';
+
+/// startTimer / pauseTimer / resumeTimer / stopTimer 호출을 기록하는 Fake.
+class FakeTimerController extends TimerController {
+  final List<String> calls = [];
+  Completer<void>? _completer;
+
+  /// 호출 시 즉시 완료하지 않고 대기하게 만든다 (더블클릭 테스트용).
+  void holdNextCall() {
+    _completer = Completer<void>();
+  }
+
+  void releaseCall() {
+    _completer?.complete();
+    _completer = null;
+  }
+
+  bool shouldThrow = false;
+
+  @override
+  FutureOr<void> build() {}
+
+  @override
+  Future<void> startTimer({
+    String? relatedTodoId,
+    String? title,
+    String? scheduleId,
+    int? allocatedDurationSeconds,
+  }) async {
+    state = const AsyncValue.loading();
+    calls.add('startTimer:$relatedTodoId');
+    if (_completer != null) await _completer!.future;
+    if (shouldThrow) {
+      state = AsyncValue.error('fail', StackTrace.current);
+      throw Exception('fail');
+    }
+    state = const AsyncValue.data(null);
+  }
+
+  @override
+  Future<void> pauseTimer({String? timerId}) async {
+    state = const AsyncValue.loading();
+    calls.add('pauseTimer:$timerId');
+    if (_completer != null) await _completer!.future;
+    if (shouldThrow) {
+      state = AsyncValue.error('fail', StackTrace.current);
+      throw Exception('fail');
+    }
+    state = const AsyncValue.data(null);
+  }
+
+  @override
+  Future<void> resumeTimer({String? timerId}) async {
+    state = const AsyncValue.loading();
+    calls.add('resumeTimer:$timerId');
+    if (_completer != null) await _completer!.future;
+    if (shouldThrow) {
+      state = AsyncValue.error('fail', StackTrace.current);
+      throw Exception('fail');
+    }
+    state = const AsyncValue.data(null);
+  }
+
+  @override
+  Future<void> stopTimer({String? timerId}) async {
+    state = const AsyncValue.loading();
+    calls.add('stopTimer:$timerId');
+    if (_completer != null) await _completer!.future;
+    if (shouldThrow) {
+      state = AsyncValue.error('fail', StackTrace.current);
+      throw Exception('fail');
+    }
+    state = const AsyncValue.data(null);
+  }
+}
+
+void main() {
+  late FakeTimerController fakeController;
+
+  const todoId = 'todo-1';
+  const timerId = 'timer-1';
+
+  const runningState = ActiveTimerState(
+    timerId: timerId,
+    elapsedSeconds: 120,
+    status: TimerStatus.running,
+  );
+
+  const pausedState = ActiveTimerState(
+    timerId: timerId,
+    elapsedSeconds: 120,
+    status: TimerStatus.paused,
+  );
+
+  setUp(() {
+    fakeController = FakeTimerController();
+  });
+
+  Widget buildWidget({ActiveTimerState? activeTimerState}) {
+    return pumpApp(
+      Scaffold(
+        body: TimerControlButtons(
+          todoId: todoId,
+          activeTimerState: activeTimerState,
+        ),
+      ),
+      overrides: [timerControllerProvider.overrideWith(() => fakeController)],
+    );
+  }
+
+  group('TimerControlButtons UI 상태', () {
+    testWidgets('활성 타이머 없으면 시작 버튼만 표시', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+      expect(find.byIcon(Icons.pause), findsNothing);
+      expect(find.byIcon(Icons.stop), findsNothing);
+    });
+
+    testWidgets('실행 중 타이머가 있으면 일시정지/정지 버튼 표시', (tester) async {
+      await tester.pumpWidget(buildWidget(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.pause), findsOneWidget);
+      expect(find.byIcon(Icons.stop), findsOneWidget);
+      expect(find.byIcon(Icons.play_arrow), findsNothing);
+    });
+
+    testWidgets('일시정지 타이머가 있으면 재생/정지 버튼 표시', (tester) async {
+      await tester.pumpWidget(buildWidget(activeTimerState: pausedState));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+      expect(find.byIcon(Icons.stop), findsOneWidget);
+      expect(find.byIcon(Icons.pause), findsNothing);
+    });
+
+    testWidgets('로딩 중에는 스피너 표시', (tester) async {
+      fakeController.holdNextCall();
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      // 시작 버튼 탭 → 로딩 상태
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byIcon(Icons.play_arrow), findsNothing);
+
+      fakeController.releaseCall();
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('타이머 시작', () {
+    testWidgets('시작 버튼 탭 시 startTimer 호출', (tester) async {
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pumpAndSettle();
+
+      expect(fakeController.calls, ['startTimer:$todoId']);
+    });
+
+    testWidgets('startTimer 실패 시 에러 SnackBar 표시', (tester) async {
+      fakeController.shouldThrow = true;
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('타이머 시작 실패'), findsOneWidget);
+    });
+  });
+
+  group('타이머 토글', () {
+    testWidgets('실행 중 일시정지 탭 시 pauseTimer 호출', (tester) async {
+      await tester.pumpWidget(buildWidget(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.pause));
+      await tester.pumpAndSettle();
+
+      expect(fakeController.calls, ['pauseTimer:$timerId']);
+    });
+
+    testWidgets('일시정지 상태에서 재생 탭 시 resumeTimer 호출', (tester) async {
+      await tester.pumpWidget(buildWidget(activeTimerState: pausedState));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pumpAndSettle();
+
+      expect(fakeController.calls, ['resumeTimer:$timerId']);
+    });
+
+    testWidgets('토글 실패 시 에러 SnackBar 표시', (tester) async {
+      fakeController.shouldThrow = true;
+
+      await tester.pumpWidget(buildWidget(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.pause));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('타이머 토글 실패'), findsOneWidget);
+    });
+  });
+
+  group('타이머 정지', () {
+    testWidgets('정지 확인 다이얼로그에서 확인 시 stopTimer 호출', (tester) async {
+      await tester.pumpWidget(buildWidget(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.stop));
+      await tester.pumpAndSettle();
+
+      // 확인 다이얼로그 표시 확인
+      expect(find.text('타이머 정지'), findsOneWidget);
+
+      // '정지' 버튼 탭 (FilledButton)
+      await tester.tap(find.widgetWithText(FilledButton, '정지'));
+      await tester.pumpAndSettle();
+
+      expect(fakeController.calls, ['stopTimer:$timerId']);
+    });
+
+    testWidgets('정지 확인 다이얼로그에서 취소 시 stopTimer 미호출', (tester) async {
+      await tester.pumpWidget(buildWidget(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.stop));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('취소'));
+      await tester.pumpAndSettle();
+
+      expect(fakeController.calls, isEmpty);
+    });
+
+    testWidgets('정지 실패 시 에러 SnackBar 표시', (tester) async {
+      fakeController.shouldThrow = true;
+
+      await tester.pumpWidget(buildWidget(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.stop));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, '정지'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('타이머 정지 실패'), findsOneWidget);
+    });
+  });
+
+  group('더블클릭 방지', () {
+    testWidgets('로딩 중 시작 버튼 연타 시 중복 호출 방지', (tester) async {
+      fakeController.holdNextCall();
+
+      await tester.pumpWidget(buildWidget());
+      await tester.pumpAndSettle();
+
+      // 첫 번째 탭
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pump();
+
+      // 로딩 상태 → 버튼 숨김 → 스피너 표시
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      // 스피너에 탭 시도 (버튼이 없으므로 무시됨)
+      expect(find.byIcon(Icons.play_arrow), findsNothing);
+
+      fakeController.releaseCall();
+      await tester.pumpAndSettle();
+
+      expect(fakeController.calls, hasLength(1));
+    });
+
+    testWidgets('로딩 중 토글 버튼 연타 시 중복 호출 방지', (tester) async {
+      fakeController.holdNextCall();
+
+      await tester.pumpWidget(buildWidget(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      // 첫 번째 탭
+      await tester.tap(find.byIcon(Icons.pause));
+      await tester.pump();
+
+      // 로딩 → 버튼 사라짐
+      expect(find.byIcon(Icons.pause), findsNothing);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+      fakeController.releaseCall();
+      await tester.pumpAndSettle();
+
+      expect(fakeController.calls, hasLength(1));
+    });
+  });
+}

--- a/test/features/todo/presentation/widgets/timer_control_buttons_test.dart
+++ b/test/features/todo/presentation/widgets/timer_control_buttons_test.dart
@@ -269,6 +269,95 @@ void main() {
     });
   });
 
+  group('상태 즉시 동기화 (provider invalidation)', () {
+    late int activeTimersFetchCount;
+    late int aggregationsFetchCount;
+
+    setUp(() {
+      activeTimersFetchCount = 0;
+      aggregationsFetchCount = 0;
+    });
+
+    Widget buildTracked({ActiveTimerState? activeTimerState}) {
+      final container = ProviderContainer(
+        overrides: [
+          timerControllerProvider.overrideWith(() => fakeController),
+          activeTimersProvider.overrideWith((ref) async {
+            activeTimersFetchCount++;
+            return [];
+          }),
+          todoTimerAggregationsProvider.overrideWith((ref) async {
+            aggregationsFetchCount++;
+            return {};
+          }),
+        ],
+      );
+      // invalidate 시 rebuild을 트리거하려면 리스너가 있어야 함
+      container.listen(activeTimersProvider, (_, __) {});
+      container.listen(todoTimerAggregationsProvider, (_, __) {});
+
+      return UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          home: Scaffold(
+            body: TimerControlButtons(
+              todoId: todoId,
+              activeTimerState: activeTimerState,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('시작 후 activeTimersProvider·todoTimerAggregationsProvider 갱신',
+        (tester) async {
+      await tester.pumpWidget(buildTracked());
+      await tester.pumpAndSettle();
+
+      final initialActive = activeTimersFetchCount;
+      final initialAgg = aggregationsFetchCount;
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pumpAndSettle();
+
+      expect(activeTimersFetchCount, greaterThan(initialActive));
+      expect(aggregationsFetchCount, greaterThan(initialAgg));
+    });
+
+    testWidgets('토글 후 activeTimersProvider·todoTimerAggregationsProvider 갱신',
+        (tester) async {
+      await tester.pumpWidget(buildTracked(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      final initialActive = activeTimersFetchCount;
+      final initialAgg = aggregationsFetchCount;
+
+      await tester.tap(find.byIcon(Icons.pause));
+      await tester.pumpAndSettle();
+
+      expect(activeTimersFetchCount, greaterThan(initialActive));
+      expect(aggregationsFetchCount, greaterThan(initialAgg));
+    });
+
+    testWidgets('정지 후 activeTimersProvider·todoTimerAggregationsProvider 갱신',
+        (tester) async {
+      await tester.pumpWidget(buildTracked(activeTimerState: runningState));
+      await tester.pumpAndSettle();
+
+      final initialActive = activeTimersFetchCount;
+      final initialAgg = aggregationsFetchCount;
+
+      await tester.tap(find.byIcon(Icons.stop));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(FilledButton, '정지'));
+      await tester.pumpAndSettle();
+
+      expect(activeTimersFetchCount, greaterThan(initialActive));
+      expect(aggregationsFetchCount, greaterThan(initialAgg));
+    });
+  });
+
   group('더블클릭 방지', () {
     testWidgets('로딩 중 시작 버튼 연타 시 중복 호출 방지', (tester) async {
       fakeController.holdNextCall();


### PR DESCRIPTION
## Change Log
- TODO 트리에서 타이머 시작/토글/정지 시 SnackBar placeholder를 실제 `timerControllerProvider` WebSocket 호출로 교체
- `_handleTimerStart`: `startTimer(relatedTodoId: todoId)` 연결
- `_handleTimerToggle`: `pauseTimer()` / `resumeTimer()` 연결 (상태 기반 분기)
- `_handleTimerStop`: `stopTimer(timerId: ...)` 연결
- 타이머 액션 후 `activeTimersProvider` · `todoTimerAggregationsProvider` 즉시 invalidate 추가
- 미사용 `TimerMutations` 클래스 삭제
- `TimerController`의 빈 REST fallback 제거 → WS 미연결 시 에러 throw로 통일
- 핸들러 진입 시 `isLoading` 가드로 더블클릭 방지
- `activeTimerStreamProvider`에 `activeTimerProvider`(WS 기반) watch 추가 — WS 이벤트 수신 시 스트림 즉시 재시작, 기존 10초 REST 폴링 제거
- `TimerControlButtons` 위젯 테스트 14건 추가

## Issue Number
closes #40
closes #58

## Checklist
- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] Code generation runs cleanly (`fvm dart run build_runner build --delete-conflicting-outputs`)
- [x] `fvm flutter analyze` passes with no issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new widget, screen, or provider).
- [ ] This PR is a breaking change (e.g. model or API client changes).