### PR TITLE
fix: async mutation의 dispose 이후 ref 접근(UnmountedRefException) 방지 (#66)

### DIFF
--- a/lib/features/calendar/presentation/providers/schedule_mutations.dart
+++ b/lib/features/calendar/presentation/providers/schedule_mutations.dart
@@ -28,38 +28,26 @@ class ScheduleMutations extends _$ScheduleMutations {
   /// [data] 생성할 일정 정보
   /// 성공 시 일정 목록을 새로고침하고, UI 로딩 상태를 관리합니다.
   Future<void> createSchedule(ScheduleCreate data) async {
-    // 이미 dispose된 상태인지 확인
-    if (!ref.mounted) return;
-
-    // 로딩 상태로 설정
     state = const AsyncValue.loading();
 
     try {
       final api = ref.read(schedulesApiProvider);
-
-      // API 호출하여 일정 생성
       final createdSchedule = await api.createScheduleV1SchedulesPost(
         body: data,
       );
 
-      // provider가 dispose되지 않았는지 확인
-      if (!ref.mounted) return;
-
-      // 성공 상태로 설정
-      state = const AsyncValue.data(null);
-
-      // 캘린더 목록 새로고침 (현재 화면에 새 일정이 바로 표시되도록)
-      ref.invalidate(currentSchedulesProvider);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(currentSchedulesProvider);
+        state = const AsyncValue.data(null);
+      }
 
       debugPrint('일정이 성공적으로 생성되었습니다: ${createdSchedule.id}');
     } catch (error, stackTrace) {
-      // provider가 dispose되지 않았는지 확인
-      if (!ref.mounted) return;
-
-      // 에러 상태로 설정
-      state = AsyncValue.error(error, stackTrace);
-
-      // 에러 로깅
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       debugPrint('일정 생성 실패: $error');
       rethrow; // UI에서 에러 처리할 수 있도록 다시 throw
     }
@@ -74,14 +62,10 @@ class ScheduleMutations extends _$ScheduleMutations {
     ScheduleUpdate data, {
     RequestOptions? options,
   }) async {
-    // 이미 dispose된 상태인지 확인
-    if (!ref.mounted) return;
-
     state = const AsyncValue.loading();
 
     try {
       final api = ref.read(schedulesApiProvider);
-
       final updatedSchedule = await api
           .updateScheduleV1SchedulesScheduleIdPatch(
             scheduleId: id,
@@ -89,18 +73,18 @@ class ScheduleMutations extends _$ScheduleMutations {
             options: options,
           );
 
-      // provider가 dispose되지 않았는지 확인
-      if (!ref.mounted) return;
-
-      state = const AsyncValue.data(null);
-      ref.invalidate(currentSchedulesProvider);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(currentSchedulesProvider);
+        state = const AsyncValue.data(null);
+      }
 
       debugPrint('일정이 성공적으로 수정되었습니다: ${updatedSchedule.id}');
     } catch (error, stackTrace) {
-      // provider가 dispose되지 않았는지 확인
-      if (!ref.mounted) return;
-
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       debugPrint('일정 수정 실패: $error');
       rethrow;
     }
@@ -110,28 +94,24 @@ class ScheduleMutations extends _$ScheduleMutations {
   ///
   /// [id] 삭제할 일정 ID
   Future<void> deleteSchedule(String id) async {
-    // 이미 dispose된 상태인지 확인
-    if (!ref.mounted) return;
-
     state = const AsyncValue.loading();
 
     try {
       final api = ref.read(schedulesApiProvider);
-
       await api.deleteScheduleV1SchedulesScheduleIdDelete(scheduleId: id);
 
-      // provider가 dispose되지 않았는지 확인
-      if (!ref.mounted) return;
-
-      state = const AsyncValue.data(null);
-      ref.invalidate(currentSchedulesProvider);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(currentSchedulesProvider);
+        state = const AsyncValue.data(null);
+      }
 
       debugPrint('일정이 성공적으로 삭제되었습니다: $id');
     } catch (error, stackTrace) {
-      // provider가 dispose되지 않았는지 확인
-      if (!ref.mounted) return;
-
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       debugPrint('일정 삭제 실패: $error');
       rethrow;
     }
@@ -142,31 +122,30 @@ class ScheduleMutations extends _$ScheduleMutations {
   /// [scheduleId] 변환할 일정 ID
   /// [tagGroupId] TODO가 속할 TagGroup ID
   Future<void> convertToTodo(String scheduleId, String tagGroupId) async {
-    if (!ref.mounted) return;
-
     state = const AsyncValue.loading();
 
     try {
       final api = ref.read(schedulesApiProvider);
-
       await api.createTodoFromScheduleV1SchedulesScheduleIdTodoPost(
         scheduleId: scheduleId,
         tagGroupId: tagGroupId,
       );
 
-      if (!ref.mounted) return;
-
-      state = const AsyncValue.data(null);
-      ref.invalidate(scheduleDetailProvider(scheduleId));
-      ref.invalidate(currentSchedulesProvider);
-      // 변환된 TODO가 특정 태그 그룹에 속할 수 있으므로 family 전체를 무효화한다.
-      ref.invalidate(todosProvider);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(scheduleDetailProvider(scheduleId));
+        ref.invalidate(currentSchedulesProvider);
+        // 변환된 TODO가 특정 태그 그룹에 속할 수 있으므로 family 전체를 무효화한다.
+        ref.invalidate(todosProvider);
+        state = const AsyncValue.data(null);
+      }
 
       debugPrint('일정이 TODO로 변환되었습니다: $scheduleId');
     } catch (error, stackTrace) {
-      if (!ref.mounted) return;
-
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       debugPrint('TODO 변환 실패: $error');
       rethrow;
     }

--- a/lib/features/tag/presentation/pages/tag_management_page.dart
+++ b/lib/features/tag/presentation/pages/tag_management_page.dart
@@ -400,9 +400,12 @@ class TagManagementPage extends ConsumerWidget {
 
     if (confirmed == true && context.mounted) {
       try {
-        await ref
-            .read(tagMutationsProvider.notifier)
-            .deleteGroup(tagGroup.groupId);
+        await deleteTagGroupMutation.run(
+          ref,
+          (tsx) => tsx
+              .get(tagGroupsRawProvider.notifier)
+              .deleteGroup(tagGroup.groupId),
+        );
 
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -463,7 +466,10 @@ class TagManagementPage extends ConsumerWidget {
 
     if (confirmed == true && context.mounted) {
       try {
-        await ref.read(tagMutationsProvider.notifier).deleteTag(tag.id);
+        await deleteTagMutation.run(
+          ref,
+          (tsx) => tsx.get(tagGroupsRawProvider.notifier).deleteTag(tag.id),
+        );
 
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/tag/presentation/widgets/tag_form_sheet.dart
+++ b/lib/features/tag/presentation/widgets/tag_form_sheet.dart
@@ -50,8 +50,9 @@ class _TagFormSheetState extends ConsumerState<TagFormSheet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final mutations = ref.watch(tagMutationsProvider);
-    final isLoading = mutations.isLoading;
+    final isLoading = _isEditMode
+        ? ref.watch(updateTagMutation).isPending
+        : ref.watch(createTagMutation).isPending;
     final availableGroupsAsync = ref.watch(tagTreeProvider);
 
     return availableGroupsAsync.when(
@@ -441,9 +442,12 @@ class _TagFormSheetState extends ConsumerState<TagFormSheet> {
           name: _nameController.text.trim(),
           color: _selectedColor.toHex(),
         );
-        await ref
-            .read(tagMutationsProvider.notifier)
-            .updateTag(widget.tag!.id, updateData);
+        await updateTagMutation.run(
+          ref,
+          (tsx) => tsx
+              .get(tagGroupsRawProvider.notifier)
+              .updateTag(widget.tag!.id, updateData),
+        );
         if (mounted) {
           navigator.pop();
           scaffoldMessenger.showSnackBar(
@@ -466,7 +470,10 @@ class _TagFormSheetState extends ConsumerState<TagFormSheet> {
           color: _selectedColor.toHex(),
           groupId: _selectedGroupId,
         );
-        await ref.read(tagMutationsProvider.notifier).createTag(createData);
+        await createTagMutation.run(
+          ref,
+          (tsx) => tsx.get(tagGroupsRawProvider.notifier).createTag(createData),
+        );
         if (mounted) {
           navigator.pop();
           _showSuccess(scaffoldMessenger, '태그가 생성되었습니다');

--- a/lib/features/tag/presentation/widgets/tag_group_form_sheet.dart
+++ b/lib/features/tag/presentation/widgets/tag_group_form_sheet.dart
@@ -49,9 +49,10 @@ class _TagGroupFormSheetState extends ConsumerState<TagGroupFormSheet> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final mutations = ref.watch(tagMutationsProvider);
-    final isLoading = mutations.isLoading;
     final isEditMode = widget.tagGroup != null;
+    final isLoading = isEditMode
+        ? ref.watch(updateTagGroupMutation).isPending
+        : ref.watch(createTagGroupMutation).isPending;
 
     // [Fix] viewInsets 패딩을 가장 바깥 Padding에만 적용한다.
     // ─ 이전 구조: Container > Padding(viewInsets) > SingleChildScrollView
@@ -319,15 +320,18 @@ class _TagGroupFormSheetState extends ConsumerState<TagGroupFormSheet> {
           description: description.isEmpty ? null : description,
         );
 
-        await ref
-            .read(tagMutationsProvider.notifier)
-            .updateGroup(
-              widget.tagGroup!.id,
-              updateData,
-              options: description.isEmpty
-                  ? explicitNulls(['description'])
-                  : null,
-            );
+        await updateTagGroupMutation.run(
+          ref,
+          (tsx) => tsx
+              .get(tagGroupsRawProvider.notifier)
+              .updateGroup(
+                widget.tagGroup!.id,
+                updateData,
+                options: description.isEmpty
+                    ? explicitNulls(['description'])
+                    : null,
+              ),
+        );
 
         if (mounted) {
           navigator.pop();
@@ -355,7 +359,11 @@ class _TagGroupFormSheetState extends ConsumerState<TagGroupFormSheet> {
               : _descriptionController.text.trim(),
         );
 
-        await ref.read(tagMutationsProvider.notifier).createGroup(createData);
+        await createTagGroupMutation.run(
+          ref,
+          (tsx) =>
+              tsx.get(tagGroupsRawProvider.notifier).createGroup(createData),
+        );
 
         if (mounted) {
           navigator.pop();

--- a/lib/features/todo/presentation/pages/todo_group_detail_page.dart
+++ b/lib/features/todo/presentation/pages/todo_group_detail_page.dart
@@ -412,7 +412,10 @@ class TodoGroupDetailPage extends ConsumerWidget {
 
     if (confirmed && context.mounted) {
       try {
-        await ref.read(tagMutationsProvider.notifier).deleteGroup(group.id);
+        await deleteTagGroupMutation.run(
+          ref,
+          (tsx) => tsx.get(tagGroupsRawProvider.notifier).deleteGroup(group.id),
+        );
 
         if (context.mounted) {
           ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/todo/presentation/providers/todo_provider.dart
+++ b/lib/features/todo/presentation/providers/todo_provider.dart
@@ -72,13 +72,17 @@ class TodoMutationsNotifier extends Notifier<AsyncValue<void>> {
       final api = ref.read(todosApiProvider);
       final response = await api.createTodoV1TodosPost(body: data);
 
-      // 목록 갱신
-      ref.invalidate(todosProvider);
-
-      state = const AsyncValue.data(null);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(todosProvider);
+        state = const AsyncValue.data(null);
+      }
       return response;
     } catch (e, st) {
-      state = AsyncValue.error(e, st);
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
       rethrow;
     }
   }
@@ -99,13 +103,17 @@ class TodoMutationsNotifier extends Notifier<AsyncValue<void>> {
         options: options,
       );
 
-      // 목록 갱신
-      ref.invalidate(todosProvider);
-
-      state = const AsyncValue.data(null);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(todosProvider);
+        state = const AsyncValue.data(null);
+      }
       return response;
     } catch (e, st) {
-      state = AsyncValue.error(e, st);
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
       rethrow;
     }
   }
@@ -118,13 +126,17 @@ class TodoMutationsNotifier extends Notifier<AsyncValue<void>> {
       final api = ref.read(todosApiProvider);
       await api.deleteTodoV1TodosTodoIdDelete(todoId: todoId);
 
-      // 목록 갱신
-      ref.invalidate(todosProvider);
-
-      state = const AsyncValue.data(null);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(todosProvider);
+        state = const AsyncValue.data(null);
+      }
       return true;
     } catch (e, st) {
-      state = AsyncValue.error(e, st);
+      if (ref.mounted) {
+        state = AsyncValue.error(e, st);
+      }
       return false;
     }
   }

--- a/lib/features/todo/presentation/widgets/todo_form_sheet.dart
+++ b/lib/features/todo/presentation/widgets/todo_form_sheet.dart
@@ -881,9 +881,12 @@ class _TodoFormSheetState extends ConsumerState<TodoFormSheet> {
             description: '할 일을 위한 기본 태그 그룹입니다.',
           );
 
-          await ref
-              .read(tag_providers.tagMutationsProvider.notifier)
-              .createGroup(defaultGroup);
+          await tag_providers.createTagGroupMutation.run(
+            ref,
+            (tsx) => tsx
+                .get(tag_providers.tagGroupsRawProvider.notifier)
+                .createGroup(defaultGroup),
+          );
 
           // 생성 후 다시 태그 그룹 데이터 가져오기
           final updatedAsync = await ref.refresh(

--- a/lib/shared/providers/tag_providers.dart
+++ b/lib/shared/providers/tag_providers.dart
@@ -97,12 +97,17 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       final result = await api.createTagGroupV1TagsGroupsPost(body: data);
 
-      ref.invalidate(tagGroupsRawProvider);
-
-      state = const AsyncValue.data(null);
+      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
+      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      if (ref.mounted) {
+        ref.invalidate(tagGroupsRawProvider);
+        state = const AsyncValue.data(null);
+      }
       return result;
     } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       rethrow;
     }
   }
@@ -127,12 +132,17 @@ class TagMutations extends _$TagMutations {
         options: options,
       );
 
-      ref.invalidate(tagGroupsRawProvider);
-
-      state = const AsyncValue.data(null);
+      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
+      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      if (ref.mounted) {
+        ref.invalidate(tagGroupsRawProvider);
+        state = const AsyncValue.data(null);
+      }
       return result;
     } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       rethrow;
     }
   }
@@ -148,11 +158,16 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       await api.deleteTagGroupV1TagsGroupsGroupIdDelete(groupId: groupId);
 
-      ref.invalidate(tagGroupsRawProvider);
+      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
+      // 건너뛴다. 삭제 API는 이미 성공했으므로 에러로 처리하지 않는다.
+      if (!ref.mounted) return;
 
+      ref.invalidate(tagGroupsRawProvider);
       state = const AsyncValue.data(null);
     } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       rethrow;
     }
   }

--- a/lib/shared/providers/tag_providers.dart
+++ b/lib/shared/providers/tag_providers.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:riverpod/experimental/mutation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:momeet/shared/providers/api_providers.dart';
 import 'package:momeet/shared/api/rest/export.dart';
@@ -7,23 +8,90 @@ import 'package:momeet/shared/domain/tag_group_with_tags.dart';
 part 'tag_providers.g.dart';
 
 // ============================================================
-// Base Data Provider (단일 API 호출)
+// Base Data + CUD Notifier
 // ============================================================
 
-/// 태그 그룹+태그 원본 데이터 Provider
+/// 태그 그룹+태그 원본 데이터와 CUD side-effect를 함께 소유하는 Notifier.
 ///
-/// `readTagGroupsV1TagsGroupsGet()`이 그룹과 태그를 모두 포함하므로
-/// 한 번의 API 호출로 모든 데이터를 가져옵니다.
+/// 설계 원칙(#66):
+/// - "데이터 캐시 + side-effect 실행"은 이 notifier가 책임진다. CUD 메서드는
+///   API 호출 후 `invalidateSelf()`로 목록을 갱신한다.
+/// - "UI operation state(pending/error/success)"는 이 클래스가 아니라 아래의
+///   [Mutation]들이 책임진다. 따라서 작업 상태 전용 notifier(과거 `TagMutations`)는
+///   두지 않는다.
+/// - CUD는 항상 `mutation.run(ref, (tsx) => tsx.get(tagGroupsRawProvider.notifier)
+///   .xxx())` 형태로 호출한다. `tsx.get`이 run 동안 이 provider를 alive로 유지하므로,
+///   호출한 화면이 먼저 dispose돼도 API 완료 후 `invalidateSelf()`가 정상 실행된다
+///   (= dispose 이후 캐시 갱신 누락이 사라진다). 그래서 메서드마다 `ref.mounted`
+///   가드를 반복할 필요가 없다.
 ///
-/// tag·todo 양쪽 feature가 공유하는 단일 소스입니다.
+/// generated REST client(`tagsApiProvider`)은 자동 생성물이라 수정하지 않고,
+/// 그 위에서 우리가 소유하는 이 계층으로만 감싼다.
 @riverpod
-Future<List<TagGroupReadWithTags>> tagGroupsRaw(Ref ref) async {
-  final api = ref.watch(tagsApiProvider);
+class TagGroupsRaw extends _$TagGroupsRaw {
+  @override
+  Future<List<TagGroupReadWithTags>> build() async {
+    final api = ref.watch(tagsApiProvider);
 
-  try {
-    return await api.readTagGroupsV1TagsGroupsGet();
-  } catch (error) {
-    throw Exception('태그 그룹 조회 실패: $error');
+    try {
+      return await api.readTagGroupsV1TagsGroupsGet();
+    } catch (error) {
+      throw Exception('태그 그룹 조회 실패: $error');
+    }
+  }
+
+  // ----- Tag Group CUD -----
+
+  /// 태그 그룹 생성
+  Future<void> createGroup(TagGroupCreate data) async {
+    await ref.read(tagsApiProvider).createTagGroupV1TagsGroupsPost(body: data);
+    ref.invalidateSelf();
+  }
+
+  /// 태그 그룹 수정
+  Future<void> updateGroup(
+    String groupId,
+    TagGroupUpdate data, {
+    RequestOptions? options,
+  }) async {
+    await ref
+        .read(tagsApiProvider)
+        .updateTagGroupV1TagsGroupsGroupIdPatch(
+          groupId: groupId,
+          body: data,
+          options: options,
+        );
+    ref.invalidateSelf();
+  }
+
+  /// 태그 그룹 삭제 (CASCADE로 하위 태그도 함께 삭제됨)
+  Future<void> deleteGroup(String groupId) async {
+    await ref
+        .read(tagsApiProvider)
+        .deleteTagGroupV1TagsGroupsGroupIdDelete(groupId: groupId);
+    ref.invalidateSelf();
+  }
+
+  // ----- Tag CUD -----
+
+  /// 태그 생성
+  Future<void> createTag(TagCreate data) async {
+    await ref.read(tagsApiProvider).createTagV1TagsPost(body: data);
+    ref.invalidateSelf();
+  }
+
+  /// 태그 수정 (그룹 이동 포함)
+  Future<void> updateTag(String tagId, TagUpdate data) async {
+    await ref
+        .read(tagsApiProvider)
+        .updateTagV1TagsTagIdPatch(tagId: tagId, body: data);
+    ref.invalidateSelf();
+  }
+
+  /// 태그 삭제
+  Future<void> deleteTag(String tagId) async {
+    await ref.read(tagsApiProvider).deleteTagV1TagsTagIdDelete(tagId: tagId);
+    ref.invalidateSelf();
   }
 }
 
@@ -71,186 +139,24 @@ Future<List<TagGroupWithTags>> tagTree(Ref ref) async {
 }
 
 // ============================================================
-// Mutation Provider (CRUD 작업)
+// Mutations (UI operation state)
 // ============================================================
 
-/// 태그 및 태그 그룹 변경 작업을 담당하는 Provider
+/// 태그/태그 그룹 CUD의 UI 작업 상태(pending/error/success)를 담는 Mutation들.
 ///
-/// 모든 CRUD 작업 후 [tagGroupsRawProvider]를 invalidate하여
-/// 파생 provider(tagGroups·tagTree)와 UI를 자동 갱신합니다.
-@riverpod
-class TagMutations extends _$TagMutations {
-  @override
-  FutureOr<void> build() {}
-
-  // ============================================================
-  // Tag Group CRUD
-  // ============================================================
-
-  /// 태그 그룹 생성
-  ///
-  /// [data] 생성할 태그 그룹 데이터
-  Future<TagGroupRead> createGroup(TagGroupCreate data) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(tagsApiProvider);
-      final result = await api.createTagGroupV1TagsGroupsPost(body: data);
-
-      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
-      // (Riverpod 3: UnmountedRefException 방지)
-      if (ref.mounted) {
-        ref.invalidate(tagGroupsRawProvider);
-        state = const AsyncValue.data(null);
-      }
-      return result;
-    } catch (error, stackTrace) {
-      if (ref.mounted) {
-        state = AsyncValue.error(error, stackTrace);
-      }
-      rethrow;
-    }
-  }
-
-  /// 태그 그룹 수정
-  ///
-  /// [groupId] 수정할 그룹 ID
-  /// [data] 수정할 데이터
-  /// [options] 명시적 null 전송 등 요청 옵션 (선택)
-  Future<TagGroupRead> updateGroup(
-    String groupId,
-    TagGroupUpdate data, {
-    RequestOptions? options,
-  }) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(tagsApiProvider);
-      final result = await api.updateTagGroupV1TagsGroupsGroupIdPatch(
-        groupId: groupId,
-        body: data,
-        options: options,
-      );
-
-      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
-      // (Riverpod 3: UnmountedRefException 방지)
-      if (ref.mounted) {
-        ref.invalidate(tagGroupsRawProvider);
-        state = const AsyncValue.data(null);
-      }
-      return result;
-    } catch (error, stackTrace) {
-      if (ref.mounted) {
-        state = AsyncValue.error(error, stackTrace);
-      }
-      rethrow;
-    }
-  }
-
-  /// 태그 그룹 삭제
-  ///
-  /// [groupId] 삭제할 그룹 ID
-  /// 주의: CASCADE로 하위 태그들도 함께 삭제됩니다.
-  Future<void> deleteGroup(String groupId) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(tagsApiProvider);
-      await api.deleteTagGroupV1TagsGroupsGroupIdDelete(groupId: groupId);
-
-      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
-      // (Riverpod 3: UnmountedRefException 방지)
-      if (ref.mounted) {
-        ref.invalidate(tagGroupsRawProvider);
-        state = const AsyncValue.data(null);
-      }
-    } catch (error, stackTrace) {
-      if (ref.mounted) {
-        state = AsyncValue.error(error, stackTrace);
-      }
-      rethrow;
-    }
-  }
-
-  // ============================================================
-  // Tag CRUD
-  // ============================================================
-
-  /// 태그 생성
-  ///
-  /// [data] 생성할 태그 데이터
-  Future<TagRead> createTag(TagCreate data) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(tagsApiProvider);
-      final result = await api.createTagV1TagsPost(body: data);
-
-      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
-      // (Riverpod 3: UnmountedRefException 방지)
-      if (ref.mounted) {
-        ref.invalidate(tagGroupsRawProvider);
-        state = const AsyncValue.data(null);
-      }
-      return result;
-    } catch (error, stackTrace) {
-      if (ref.mounted) {
-        state = AsyncValue.error(error, stackTrace);
-      }
-      rethrow;
-    }
-  }
-
-  /// 태그 수정 (그룹 이동 포함)
-  ///
-  /// [tagId] 수정할 태그 ID
-  /// [data] 수정할 데이터
-  Future<TagRead> updateTag(String tagId, TagUpdate data) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(tagsApiProvider);
-      final result = await api.updateTagV1TagsTagIdPatch(
-        tagId: tagId,
-        body: data,
-      );
-
-      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
-      // (Riverpod 3: UnmountedRefException 방지)
-      if (ref.mounted) {
-        ref.invalidate(tagGroupsRawProvider);
-        state = const AsyncValue.data(null);
-      }
-      return result;
-    } catch (error, stackTrace) {
-      if (ref.mounted) {
-        state = AsyncValue.error(error, stackTrace);
-      }
-      rethrow;
-    }
-  }
-
-  /// 태그 삭제
-  ///
-  /// [tagId] 삭제할 태그 ID
-  Future<void> deleteTag(String tagId) async {
-    state = const AsyncValue.loading();
-
-    try {
-      final api = ref.read(tagsApiProvider);
-      await api.deleteTagV1TagsTagIdDelete(tagId: tagId);
-
-      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
-      // (Riverpod 3: UnmountedRefException 방지)
-      if (ref.mounted) {
-        ref.invalidate(tagGroupsRawProvider);
-        state = const AsyncValue.data(null);
-      }
-    } catch (error, stackTrace) {
-      if (ref.mounted) {
-        state = AsyncValue.error(error, stackTrace);
-      }
-      rethrow;
-    }
-  }
-}
+/// 사용 예:
+/// ```dart
+/// // 상태 구독
+/// final isDeleting = ref.watch(deleteTagGroupMutation).isPending;
+/// // 실행
+/// await deleteTagGroupMutation.run(
+///   ref,
+///   (tsx) => tsx.get(tagGroupsRawProvider.notifier).deleteGroup(id),
+/// );
+/// ```
+final createTagGroupMutation = Mutation<void>(label: 'createTagGroup');
+final updateTagGroupMutation = Mutation<void>(label: 'updateTagGroup');
+final deleteTagGroupMutation = Mutation<void>(label: 'deleteTagGroup');
+final createTagMutation = Mutation<void>(label: 'createTag');
+final updateTagMutation = Mutation<void>(label: 'updateTag');
+final deleteTagMutation = Mutation<void>(label: 'deleteTag');

--- a/lib/shared/providers/tag_providers.dart
+++ b/lib/shared/providers/tag_providers.dart
@@ -186,12 +186,17 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       final result = await api.createTagV1TagsPost(body: data);
 
-      ref.invalidate(tagGroupsRawProvider);
-
-      state = const AsyncValue.data(null);
+      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
+      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      if (ref.mounted) {
+        ref.invalidate(tagGroupsRawProvider);
+        state = const AsyncValue.data(null);
+      }
       return result;
     } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       rethrow;
     }
   }
@@ -210,12 +215,17 @@ class TagMutations extends _$TagMutations {
         body: data,
       );
 
-      ref.invalidate(tagGroupsRawProvider);
-
-      state = const AsyncValue.data(null);
+      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
+      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      if (ref.mounted) {
+        ref.invalidate(tagGroupsRawProvider);
+        state = const AsyncValue.data(null);
+      }
       return result;
     } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       rethrow;
     }
   }
@@ -230,11 +240,16 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       await api.deleteTagV1TagsTagIdDelete(tagId: tagId);
 
-      ref.invalidate(tagGroupsRawProvider);
+      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
+      // 건너뛴다. 삭제 API는 이미 성공했으므로 에러로 처리하지 않는다.
+      if (!ref.mounted) return;
 
+      ref.invalidate(tagGroupsRawProvider);
       state = const AsyncValue.data(null);
     } catch (error, stackTrace) {
-      state = AsyncValue.error(error, stackTrace);
+      if (ref.mounted) {
+        state = AsyncValue.error(error, stackTrace);
+      }
       rethrow;
     }
   }

--- a/lib/shared/providers/tag_providers.dart
+++ b/lib/shared/providers/tag_providers.dart
@@ -97,8 +97,8 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       final result = await api.createTagGroupV1TagsGroupsPost(body: data);
 
-      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
-      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
       if (ref.mounted) {
         ref.invalidate(tagGroupsRawProvider);
         state = const AsyncValue.data(null);
@@ -132,8 +132,8 @@ class TagMutations extends _$TagMutations {
         options: options,
       );
 
-      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
-      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
       if (ref.mounted) {
         ref.invalidate(tagGroupsRawProvider);
         state = const AsyncValue.data(null);
@@ -158,12 +158,12 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       await api.deleteTagGroupV1TagsGroupsGroupIdDelete(groupId: groupId);
 
-      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
-      // 건너뛴다. 삭제 API는 이미 성공했으므로 에러로 처리하지 않는다.
-      if (!ref.mounted) return;
-
-      ref.invalidate(tagGroupsRawProvider);
-      state = const AsyncValue.data(null);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(tagGroupsRawProvider);
+        state = const AsyncValue.data(null);
+      }
     } catch (error, stackTrace) {
       if (ref.mounted) {
         state = AsyncValue.error(error, stackTrace);
@@ -186,8 +186,8 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       final result = await api.createTagV1TagsPost(body: data);
 
-      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
-      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
       if (ref.mounted) {
         ref.invalidate(tagGroupsRawProvider);
         state = const AsyncValue.data(null);
@@ -215,8 +215,8 @@ class TagMutations extends _$TagMutations {
         body: data,
       );
 
-      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
-      // 건너뛴다. API는 이미 성공했으므로 결과는 그대로 반환한다.
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
       if (ref.mounted) {
         ref.invalidate(tagGroupsRawProvider);
         state = const AsyncValue.data(null);
@@ -240,12 +240,12 @@ class TagMutations extends _$TagMutations {
       final api = ref.read(tagsApiProvider);
       await api.deleteTagV1TagsTagIdDelete(tagId: tagId);
 
-      // 화면 이탈 등으로 autoDispose provider가 dispose되면 ref 후처리를
-      // 건너뛴다. 삭제 API는 이미 성공했으므로 에러로 처리하지 않는다.
-      if (!ref.mounted) return;
-
-      ref.invalidate(tagGroupsRawProvider);
-      state = const AsyncValue.data(null);
+      // async gap(await) 이후 provider가 dispose됐으면 ref/state를 만지지 않는다.
+      // (Riverpod 3: UnmountedRefException 방지)
+      if (ref.mounted) {
+        ref.invalidate(tagGroupsRawProvider);
+        state = const AsyncValue.data(null);
+      }
     } catch (error, stackTrace) {
       if (ref.mounted) {
         state = AsyncValue.error(error, stackTrace);

--- a/test/shared/providers/mutation_dispose_safety_test.dart
+++ b/test/shared/providers/mutation_dispose_safety_test.dart
@@ -7,33 +7,24 @@ import 'package:momeet/features/calendar/presentation/providers/schedule_mutatio
 import 'package:momeet/features/todo/presentation/providers/todo_provider.dart';
 import 'package:momeet/shared/api/rest/export.dart';
 import 'package:momeet/shared/providers/api_providers.dart';
-import 'package:momeet/shared/providers/tag_providers.dart';
 
 import '../../helpers/schedule_fixtures.dart';
 
-// 정책: 모든 async mutation은 await(=async gap) 이후 provider가 dispose되면
-// ref/state를 만지지 않는다. 화면 이탈·scope teardown 등으로 mutation provider가
-// 먼저 dispose된 뒤 API 응답이 도착해도 Riverpod의 UnmountedRefException
-// ("Cannot use the Ref ... after it has been disposed")이 발생하면 안 된다.
+// 정책: ref.mounted 가드 기반 mutation notifier(ScheduleMutations·
+// TodoMutationsNotifier)는 await(=async gap) 이후 provider가 dispose돼도
+// ref/state를 만지지 않는다. 화면 이탈·scope teardown 등으로 provider가 먼저
+// dispose된 뒤 API 응답이 도착해도 UnmountedRefException이 발생하면 안 된다.
 //
 // 각 mutation마다 두 경로를 본다.
-//   - 성공 직전 dispose: ref 후처리를 건너뛰되 결과/완료는 정상 반환
+//   - 성공 직전 dispose: ref 후처리를 건너뛰되 결과/완료는 정상
 //   - 실패 직전 dispose: catch의 state 갱신을 건너뛰되 "원래 에러"가 전파
-//     (disposed-ref 에러로 뒤바뀌지 않아야 함)
-
-class MockTagsClient extends Mock implements TagsClient {}
+//
+// (Tag 도메인은 Mutation API 기반으로 전환되어 이 가드 패턴을 쓰지 않으므로,
+//  해당 검증은 tag_providers_test.dart 로 분리되어 있다.)
 
 class MockSchedulesClient extends Mock implements SchedulesClient {}
 
 class MockTodosClient extends Mock implements TodosClient {}
-
-class FakeTagGroupCreate extends Fake implements TagGroupCreate {}
-
-class FakeTagGroupUpdate extends Fake implements TagGroupUpdate {}
-
-class FakeTagCreate extends Fake implements TagCreate {}
-
-class FakeTagUpdate extends Fake implements TagUpdate {}
 
 class FakeScheduleCreate extends Fake implements ScheduleCreate {}
 
@@ -55,14 +46,6 @@ final Matcher _propagatesOriginalError = throwsA(
         !e.toString().contains('disposed'),
     'rethrows the original error, not a disposed-ref error',
   ),
-);
-
-TagGroupRead _tagGroup() => TagGroupRead(
-  id: 'group-1',
-  name: 'group',
-  color: '#3498DB',
-  createdAt: DateTime(2025, 1, 1),
-  updatedAt: DateTime(2025, 1, 1),
 );
 
 TodoRead _todo() => TodoRead(
@@ -100,217 +83,10 @@ Future<T> _disposeDuringAwait<T>(
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(FakeTagGroupCreate());
-    registerFallbackValue(FakeTagGroupUpdate());
-    registerFallbackValue(FakeTagCreate());
-    registerFallbackValue(FakeTagUpdate());
     registerFallbackValue(FakeScheduleCreate());
     registerFallbackValue(FakeScheduleUpdate());
     registerFallbackValue(FakeTodoCreate());
     registerFallbackValue(FakeTodoUpdate());
-  });
-
-  group('TagMutations: async gap 이후 dispose 안전성', () {
-    late MockTagsClient api;
-    late ProviderContainer container;
-    TagMutations notifier() => container.read(tagMutationsProvider.notifier);
-
-    setUp(() {
-      api = MockTagsClient();
-      container = _container([tagsApiProvider.overrideWithValue(api)]);
-    });
-
-    group('createGroup', () {
-      void stub(Completer<TagGroupRead> pending) => when(
-        () => api.createTagGroupV1TagsGroupsPost(
-          body: any(named: 'body'),
-          options: any(named: 'options'),
-        ),
-      ).thenAnswer((_) => pending.future);
-      final data = TagGroupCreate(name: 'g', color: '#000000');
-
-      test('성공 직전 dispose돼도 결과를 반환한다', () async {
-        final pending = Completer<TagGroupRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().createGroup(data),
-          () => pending.complete(_tagGroup()),
-        );
-        await expectLater(result, completion(isA<TagGroupRead>()));
-      });
-
-      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
-        final pending = Completer<TagGroupRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().createGroup(data),
-          () => pending.completeError(_apiError),
-        );
-        await expectLater(result, _propagatesOriginalError);
-      });
-    });
-
-    group('updateGroup', () {
-      void stub(Completer<TagGroupRead> pending) => when(
-        () => api.updateTagGroupV1TagsGroupsGroupIdPatch(
-          groupId: any(named: 'groupId'),
-          body: any(named: 'body'),
-          options: any(named: 'options'),
-        ),
-      ).thenAnswer((_) => pending.future);
-      final data = TagGroupUpdate(name: 'g2');
-
-      test('성공 직전 dispose돼도 결과를 반환한다', () async {
-        final pending = Completer<TagGroupRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().updateGroup('group-1', data),
-          () => pending.complete(_tagGroup()),
-        );
-        await expectLater(result, completion(isA<TagGroupRead>()));
-      });
-
-      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
-        final pending = Completer<TagGroupRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().updateGroup('group-1', data),
-          () => pending.completeError(_apiError),
-        );
-        await expectLater(result, _propagatesOriginalError);
-      });
-    });
-
-    group('deleteGroup', () {
-      void stub(Completer<void> pending) => when(
-        () => api.deleteTagGroupV1TagsGroupsGroupIdDelete(
-          groupId: any(named: 'groupId'),
-          options: any(named: 'options'),
-        ),
-      ).thenAnswer((_) => pending.future);
-
-      test('성공 직전 dispose돼도 정상 완료한다', () async {
-        final pending = Completer<void>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().deleteGroup('group-1'),
-          () => pending.complete(),
-        );
-        await expectLater(result, completes);
-      });
-
-      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
-        final pending = Completer<void>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().deleteGroup('group-1'),
-          () => pending.completeError(_apiError),
-        );
-        await expectLater(result, _propagatesOriginalError);
-      });
-    });
-
-    group('createTag', () {
-      void stub(Completer<TagRead> pending) => when(
-        () => api.createTagV1TagsPost(
-          body: any(named: 'body'),
-          options: any(named: 'options'),
-        ),
-      ).thenAnswer((_) => pending.future);
-      final data = TagCreate(name: 't', color: '#FF5733', groupId: 'group-1');
-
-      test('성공 직전 dispose돼도 결과를 반환한다', () async {
-        final pending = Completer<TagRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().createTag(data),
-          () => pending.complete(makeTag()),
-        );
-        await expectLater(result, completion(isA<TagRead>()));
-      });
-
-      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
-        final pending = Completer<TagRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().createTag(data),
-          () => pending.completeError(_apiError),
-        );
-        await expectLater(result, _propagatesOriginalError);
-      });
-    });
-
-    group('updateTag', () {
-      void stub(Completer<TagRead> pending) => when(
-        () => api.updateTagV1TagsTagIdPatch(
-          tagId: any(named: 'tagId'),
-          body: any(named: 'body'),
-          options: any(named: 'options'),
-        ),
-      ).thenAnswer((_) => pending.future);
-      final data = TagUpdate(name: 't2');
-
-      test('성공 직전 dispose돼도 결과를 반환한다', () async {
-        final pending = Completer<TagRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().updateTag('tag-1', data),
-          () => pending.complete(makeTag()),
-        );
-        await expectLater(result, completion(isA<TagRead>()));
-      });
-
-      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
-        final pending = Completer<TagRead>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().updateTag('tag-1', data),
-          () => pending.completeError(_apiError),
-        );
-        await expectLater(result, _propagatesOriginalError);
-      });
-    });
-
-    group('deleteTag', () {
-      void stub(Completer<void> pending) => when(
-        () => api.deleteTagV1TagsTagIdDelete(
-          tagId: any(named: 'tagId'),
-          options: any(named: 'options'),
-        ),
-      ).thenAnswer((_) => pending.future);
-
-      test('성공 직전 dispose돼도 정상 완료한다', () async {
-        final pending = Completer<void>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().deleteTag('tag-1'),
-          () => pending.complete(),
-        );
-        await expectLater(result, completes);
-      });
-
-      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
-        final pending = Completer<void>();
-        stub(pending);
-        final result = _disposeDuringAwait(
-          container,
-          notifier().deleteTag('tag-1'),
-          () => pending.completeError(_apiError),
-        );
-        await expectLater(result, _propagatesOriginalError);
-      });
-    });
   });
 
   group('ScheduleMutations: async gap 이후 dispose 안전성', () {

--- a/test/shared/providers/mutation_dispose_safety_test.dart
+++ b/test/shared/providers/mutation_dispose_safety_test.dart
@@ -1,0 +1,563 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:momeet/features/calendar/presentation/providers/schedule_mutations.dart';
+import 'package:momeet/features/todo/presentation/providers/todo_provider.dart';
+import 'package:momeet/shared/api/rest/export.dart';
+import 'package:momeet/shared/providers/api_providers.dart';
+import 'package:momeet/shared/providers/tag_providers.dart';
+
+import '../../helpers/schedule_fixtures.dart';
+
+// 정책: 모든 async mutation은 await(=async gap) 이후 provider가 dispose되면
+// ref/state를 만지지 않는다. 화면 이탈·scope teardown 등으로 mutation provider가
+// 먼저 dispose된 뒤 API 응답이 도착해도 Riverpod의 UnmountedRefException
+// ("Cannot use the Ref ... after it has been disposed")이 발생하면 안 된다.
+//
+// 각 mutation마다 두 경로를 본다.
+//   - 성공 직전 dispose: ref 후처리를 건너뛰되 결과/완료는 정상 반환
+//   - 실패 직전 dispose: catch의 state 갱신을 건너뛰되 "원래 에러"가 전파
+//     (disposed-ref 에러로 뒤바뀌지 않아야 함)
+
+class MockTagsClient extends Mock implements TagsClient {}
+
+class MockSchedulesClient extends Mock implements SchedulesClient {}
+
+class MockTodosClient extends Mock implements TodosClient {}
+
+class FakeTagGroupCreate extends Fake implements TagGroupCreate {}
+
+class FakeTagGroupUpdate extends Fake implements TagGroupUpdate {}
+
+class FakeTagCreate extends Fake implements TagCreate {}
+
+class FakeTagUpdate extends Fake implements TagUpdate {}
+
+class FakeScheduleCreate extends Fake implements ScheduleCreate {}
+
+class FakeScheduleUpdate extends Fake implements ScheduleUpdate {}
+
+class FakeTodoCreate extends Fake implements TodoCreate {}
+
+class FakeTodoUpdate extends Fake implements TodoUpdate {}
+
+/// API 호출 실패를 흉내 내는 에러.
+final Exception _apiError = Exception('api-failure');
+
+/// dispose 이후 실패 경로에서 "원래 에러"가 그대로 전파되고,
+/// disposed-ref 에러로 뒤바뀌지 않았음을 확인하는 matcher.
+final Matcher _propagatesOriginalError = throwsA(
+  predicate(
+    (Object? e) =>
+        e.toString().contains('api-failure') &&
+        !e.toString().contains('disposed'),
+    'rethrows the original error, not a disposed-ref error',
+  ),
+);
+
+TagGroupRead _tagGroup() => TagGroupRead(
+  id: 'group-1',
+  name: 'group',
+  color: '#3498DB',
+  createdAt: DateTime(2025, 1, 1),
+  updatedAt: DateTime(2025, 1, 1),
+);
+
+TodoRead _todo() => TodoRead(
+  id: 'todo-1',
+  title: 'todo',
+  tagGroupId: 'group-1',
+  status: TodoStatus.unscheduled,
+  createdAt: DateTime(2025, 1, 1),
+);
+
+ProviderContainer _container(dynamic overrides) {
+  final container = ProviderContainer(overrides: overrides);
+  addTearDown(() {
+    try {
+      container.dispose();
+    } catch (_) {
+      // 일부 테스트는 pending API 완료 전에 의도적으로 dispose한다.
+    }
+  });
+  return container;
+}
+
+/// await 도중 container를 dispose시킨 뒤 pending 작업을 마무리한다.
+/// 이미 시작된 [mutation] future를 그대로 돌려주므로 호출부에서 matcher로 검증한다.
+Future<T> _disposeDuringAwait<T>(
+  ProviderContainer container,
+  Future<T> mutation,
+  void Function() settle,
+) async {
+  await Future<void>.delayed(Duration.zero);
+  container.dispose();
+  settle();
+  return mutation;
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeTagGroupCreate());
+    registerFallbackValue(FakeTagGroupUpdate());
+    registerFallbackValue(FakeTagCreate());
+    registerFallbackValue(FakeTagUpdate());
+    registerFallbackValue(FakeScheduleCreate());
+    registerFallbackValue(FakeScheduleUpdate());
+    registerFallbackValue(FakeTodoCreate());
+    registerFallbackValue(FakeTodoUpdate());
+  });
+
+  group('TagMutations: async gap 이후 dispose 안전성', () {
+    late MockTagsClient api;
+    late ProviderContainer container;
+    TagMutations notifier() => container.read(tagMutationsProvider.notifier);
+
+    setUp(() {
+      api = MockTagsClient();
+      container = _container([tagsApiProvider.overrideWithValue(api)]);
+    });
+
+    group('createGroup', () {
+      void stub(Completer<TagGroupRead> pending) => when(
+        () => api.createTagGroupV1TagsGroupsPost(
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+      final data = TagGroupCreate(name: 'g', color: '#000000');
+
+      test('성공 직전 dispose돼도 결과를 반환한다', () async {
+        final pending = Completer<TagGroupRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().createGroup(data),
+          () => pending.complete(_tagGroup()),
+        );
+        await expectLater(result, completion(isA<TagGroupRead>()));
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<TagGroupRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().createGroup(data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('updateGroup', () {
+      void stub(Completer<TagGroupRead> pending) => when(
+        () => api.updateTagGroupV1TagsGroupsGroupIdPatch(
+          groupId: any(named: 'groupId'),
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+      final data = TagGroupUpdate(name: 'g2');
+
+      test('성공 직전 dispose돼도 결과를 반환한다', () async {
+        final pending = Completer<TagGroupRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().updateGroup('group-1', data),
+          () => pending.complete(_tagGroup()),
+        );
+        await expectLater(result, completion(isA<TagGroupRead>()));
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<TagGroupRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().updateGroup('group-1', data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('deleteGroup', () {
+      void stub(Completer<void> pending) => when(
+        () => api.deleteTagGroupV1TagsGroupsGroupIdDelete(
+          groupId: any(named: 'groupId'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+
+      test('성공 직전 dispose돼도 정상 완료한다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().deleteGroup('group-1'),
+          () => pending.complete(),
+        );
+        await expectLater(result, completes);
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().deleteGroup('group-1'),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('createTag', () {
+      void stub(Completer<TagRead> pending) => when(
+        () => api.createTagV1TagsPost(
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+      final data = TagCreate(name: 't', color: '#FF5733', groupId: 'group-1');
+
+      test('성공 직전 dispose돼도 결과를 반환한다', () async {
+        final pending = Completer<TagRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().createTag(data),
+          () => pending.complete(makeTag()),
+        );
+        await expectLater(result, completion(isA<TagRead>()));
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<TagRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().createTag(data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('updateTag', () {
+      void stub(Completer<TagRead> pending) => when(
+        () => api.updateTagV1TagsTagIdPatch(
+          tagId: any(named: 'tagId'),
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+      final data = TagUpdate(name: 't2');
+
+      test('성공 직전 dispose돼도 결과를 반환한다', () async {
+        final pending = Completer<TagRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().updateTag('tag-1', data),
+          () => pending.complete(makeTag()),
+        );
+        await expectLater(result, completion(isA<TagRead>()));
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<TagRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().updateTag('tag-1', data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('deleteTag', () {
+      void stub(Completer<void> pending) => when(
+        () => api.deleteTagV1TagsTagIdDelete(
+          tagId: any(named: 'tagId'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+
+      test('성공 직전 dispose돼도 정상 완료한다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().deleteTag('tag-1'),
+          () => pending.complete(),
+        );
+        await expectLater(result, completes);
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().deleteTag('tag-1'),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+  });
+
+  group('ScheduleMutations: async gap 이후 dispose 안전성', () {
+    late MockSchedulesClient api;
+    late ProviderContainer container;
+    ScheduleMutations notifier() =>
+        container.read(scheduleMutationsProvider.notifier);
+
+    setUp(() {
+      api = MockSchedulesClient();
+      container = _container([schedulesApiProvider.overrideWithValue(api)]);
+    });
+
+    group('createSchedule', () {
+      void stub(Completer<ScheduleRead> pending) => when(
+        () => api.createScheduleV1SchedulesPost(body: any(named: 'body')),
+      ).thenAnswer((_) => pending.future);
+      final data = ScheduleCreate(
+        title: 's',
+        startTime: DateTime.utc(2026, 1, 1, 9),
+        endTime: DateTime.utc(2026, 1, 1, 10),
+      );
+
+      test('성공 직전 dispose돼도 정상 완료한다', () async {
+        final pending = Completer<ScheduleRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().createSchedule(data),
+          () => pending.complete(makeSchedule()),
+        );
+        await expectLater(result, completes);
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<ScheduleRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().createSchedule(data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('updateSchedule', () {
+      void stub(Completer<ScheduleRead> pending) => when(
+        () => api.updateScheduleV1SchedulesScheduleIdPatch(
+          scheduleId: any(named: 'scheduleId'),
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+      final data = ScheduleUpdate(title: 's2');
+
+      test('성공 직전 dispose돼도 정상 완료한다', () async {
+        final pending = Completer<ScheduleRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().updateSchedule('schedule-1', data),
+          () => pending.complete(makeSchedule()),
+        );
+        await expectLater(result, completes);
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<ScheduleRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().updateSchedule('schedule-1', data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('deleteSchedule', () {
+      void stub(Completer<void> pending) => when(
+        () => api.deleteScheduleV1SchedulesScheduleIdDelete(
+          scheduleId: any(named: 'scheduleId'),
+          instanceStart: any(named: 'instanceStart'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+
+      test('성공 직전 dispose돼도 정상 완료한다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().deleteSchedule('schedule-1'),
+          () => pending.complete(),
+        );
+        await expectLater(result, completes);
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().deleteSchedule('schedule-1'),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('convertToTodo', () {
+      void stub(Completer<void> pending) => when(
+        () => api.createTodoFromScheduleV1SchedulesScheduleIdTodoPost(
+          scheduleId: any(named: 'scheduleId'),
+          tagGroupId: any(named: 'tagGroupId'),
+        ),
+      ).thenAnswer((_) => pending.future);
+
+      test('성공 직전 dispose돼도 정상 완료한다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().convertToTodo('schedule-1', 'group-1'),
+          () => pending.complete(),
+        );
+        await expectLater(result, completes);
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().convertToTodo('schedule-1', 'group-1'),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+  });
+
+  group('TodoMutationsNotifier: async gap 이후 dispose 안전성', () {
+    late MockTodosClient api;
+    late ProviderContainer container;
+    TodoMutationsNotifier notifier() =>
+        container.read(todoMutationsProvider.notifier);
+
+    setUp(() {
+      api = MockTodosClient();
+      container = _container([todosApiProvider.overrideWithValue(api)]);
+    });
+
+    group('create', () {
+      void stub(Completer<TodoRead> pending) => when(
+        () => api.createTodoV1TodosPost(body: any(named: 'body')),
+      ).thenAnswer((_) => pending.future);
+      final data = TodoCreate(title: 'todo', tagGroupId: 'group-1');
+
+      test('성공 직전 dispose돼도 결과를 반환한다', () async {
+        final pending = Completer<TodoRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().create(data),
+          () => pending.complete(_todo()),
+        );
+        await expectLater(result, completion(isA<TodoRead>()));
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<TodoRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().create(data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('update', () {
+      void stub(Completer<TodoRead> pending) => when(
+        () => api.updateTodoV1TodosTodoIdPatch(
+          todoId: any(named: 'todoId'),
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+      final data = TodoUpdate(title: 'todo2');
+
+      test('성공 직전 dispose돼도 결과를 반환한다', () async {
+        final pending = Completer<TodoRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().update('todo-1', data),
+          () => pending.complete(_todo()),
+        );
+        await expectLater(result, completion(isA<TodoRead>()));
+      });
+
+      test('실패 직전 dispose돼도 원래 에러를 던진다', () async {
+        final pending = Completer<TodoRead>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().update('todo-1', data),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, _propagatesOriginalError);
+      });
+    });
+
+    group('delete', () {
+      void stub(Completer<void> pending) => when(
+        () => api.deleteTodoV1TodosTodoIdDelete(
+          todoId: any(named: 'todoId'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) => pending.future);
+
+      // delete는 에러를 rethrow하지 않고 bool로 결과를 알리는 계약이라
+      // 성공/실패 각각 true/false로 완료되어야 한다(둘 다 disposed-ref 에러 없이).
+      test('성공 직전 dispose돼도 true로 완료한다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().delete('todo-1'),
+          () => pending.complete(),
+        );
+        await expectLater(result, completion(isTrue));
+      });
+
+      test('실패 직전 dispose돼도 false로 완료한다', () async {
+        final pending = Completer<void>();
+        stub(pending);
+        final result = _disposeDuringAwait(
+          container,
+          notifier().delete('todo-1'),
+          () => pending.completeError(_apiError),
+        );
+        await expectLater(result, completion(isFalse));
+      });
+    });
+  });
+}

--- a/test/shared/providers/tag_providers_test.dart
+++ b/test/shared/providers/tag_providers_test.dart
@@ -9,7 +9,11 @@ class MockTagsClient extends Mock implements TagsClient {}
 
 class FakeTagGroupCreate extends Fake implements TagGroupCreate {}
 
+class FakeTagGroupUpdate extends Fake implements TagGroupUpdate {}
+
 class FakeTagCreate extends Fake implements TagCreate {}
+
+class FakeTagUpdate extends Fake implements TagUpdate {}
 
 TagGroupReadWithTags _group(
   String id,
@@ -42,7 +46,9 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakeTagGroupCreate());
+    registerFallbackValue(FakeTagGroupUpdate());
     registerFallbackValue(FakeTagCreate());
+    registerFallbackValue(FakeTagUpdate());
   });
 
   setUp(() {
@@ -61,6 +67,14 @@ void main() {
     when(
       () => api.readTagGroupsV1TagsGroupsGet(options: any(named: 'options')),
     ).thenAnswer((_) async => groups);
+  }
+
+  /// CUD 메서드는 invalidateSelf로 목록을 갱신하므로, 호출 동안 provider가
+  /// autoDispose되지 않게 목록을 구독한 컨테이너를 만든다(=목록 화면이 떠 있는 상황).
+  ProviderContainer listeningContainer() {
+    final container = makeContainer();
+    container.listen(tagGroupsRawProvider, (_, _) {});
+    return container;
   }
 
   group('파생 provider', () {
@@ -103,29 +117,29 @@ void main() {
     });
   });
 
-  group('TagMutations - 태그 그룹 CRUD', () {
-    test('createGroup은 API를 호출하고 결과를 반환한다', () async {
+  group('TagGroupsRaw - CUD 메서드는 해당 REST API를 호출한다', () {
+    test('createGroup', () async {
       stubRead([]);
-      final created = TagGroupRead(
-        id: 'g1',
-        name: 'New',
-        color: '#000000',
-        createdAt: DateTime(2025, 1, 1),
-        updatedAt: DateTime(2025, 1, 1),
-      );
       when(
         () => api.createTagGroupV1TagsGroupsPost(
           body: any(named: 'body'),
           options: any(named: 'options'),
         ),
-      ).thenAnswer((_) async => created);
+      ).thenAnswer(
+        (_) async => TagGroupRead(
+          id: 'g1',
+          name: 'New',
+          color: '#000000',
+          createdAt: DateTime(2025, 1, 1),
+          updatedAt: DateTime(2025, 1, 1),
+        ),
+      );
 
-      final container = makeContainer();
-      final result = await container
-          .read(tagMutationsProvider.notifier)
+      final container = listeningContainer();
+      await container
+          .read(tagGroupsRawProvider.notifier)
           .createGroup(TagGroupCreate(name: 'New', color: '#000000'));
 
-      expect(result, created);
       verify(
         () => api.createTagGroupV1TagsGroupsPost(
           body: any(named: 'body'),
@@ -134,7 +148,39 @@ void main() {
       ).called(1);
     });
 
-    test('deleteGroup은 API를 호출한다', () async {
+    test('updateGroup', () async {
+      stubRead([]);
+      when(
+        () => api.updateTagGroupV1TagsGroupsGroupIdPatch(
+          groupId: any(named: 'groupId'),
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer(
+        (_) async => TagGroupRead(
+          id: 'g1',
+          name: 'Up',
+          color: '#000000',
+          createdAt: DateTime(2025, 1, 1),
+          updatedAt: DateTime(2025, 1, 1),
+        ),
+      );
+
+      final container = listeningContainer();
+      await container
+          .read(tagGroupsRawProvider.notifier)
+          .updateGroup('g1', TagGroupUpdate(name: 'Up'));
+
+      verify(
+        () => api.updateTagGroupV1TagsGroupsGroupIdPatch(
+          groupId: 'g1',
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).called(1);
+    });
+
+    test('deleteGroup', () async {
       stubRead([]);
       when(
         () => api.deleteTagGroupV1TagsGroupsGroupIdDelete(
@@ -143,8 +189,8 @@ void main() {
         ),
       ).thenAnswer((_) async {});
 
-      final container = makeContainer();
-      await container.read(tagMutationsProvider.notifier).deleteGroup('g1');
+      final container = listeningContainer();
+      await container.read(tagGroupsRawProvider.notifier).deleteGroup('g1');
 
       verify(
         () => api.deleteTagGroupV1TagsGroupsGroupIdDelete(
@@ -153,25 +199,21 @@ void main() {
         ),
       ).called(1);
     });
-  });
 
-  group('TagMutations - 태그 CRUD', () {
-    test('createTag은 API를 호출한다', () async {
+    test('createTag', () async {
       stubRead([]);
-      final created = _tag('t1', 'g1');
       when(
         () => api.createTagV1TagsPost(
           body: any(named: 'body'),
           options: any(named: 'options'),
         ),
-      ).thenAnswer((_) async => created);
+      ).thenAnswer((_) async => _tag('t1', 'g1'));
 
-      final container = makeContainer();
-      final result = await container
-          .read(tagMutationsProvider.notifier)
+      final container = listeningContainer();
+      await container
+          .read(tagGroupsRawProvider.notifier)
           .createTag(TagCreate(name: 'tag', color: '#FF5733', groupId: 'g1'));
 
-      expect(result, created);
       verify(
         () => api.createTagV1TagsPost(
           body: any(named: 'body'),
@@ -180,7 +222,31 @@ void main() {
       ).called(1);
     });
 
-    test('deleteTag은 API를 호출한다', () async {
+    test('updateTag', () async {
+      stubRead([]);
+      when(
+        () => api.updateTagV1TagsTagIdPatch(
+          tagId: any(named: 'tagId'),
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) async => _tag('t1', 'g1'));
+
+      final container = listeningContainer();
+      await container
+          .read(tagGroupsRawProvider.notifier)
+          .updateTag('t1', TagUpdate(name: 'up'));
+
+      verify(
+        () => api.updateTagV1TagsTagIdPatch(
+          tagId: 't1',
+          body: any(named: 'body'),
+          options: any(named: 'options'),
+        ),
+      ).called(1);
+    });
+
+    test('deleteTag', () async {
       stubRead([]);
       when(
         () => api.deleteTagV1TagsTagIdDelete(
@@ -189,8 +255,8 @@ void main() {
         ),
       ).thenAnswer((_) async {});
 
-      final container = makeContainer();
-      await container.read(tagMutationsProvider.notifier).deleteTag('t1');
+      final container = listeningContainer();
+      await container.read(tagGroupsRawProvider.notifier).deleteTag('t1');
 
       verify(
         () => api.deleteTagV1TagsTagIdDelete(
@@ -201,8 +267,8 @@ void main() {
     });
   });
 
-  group('TagMutations - 캐시 무효화', () {
-    test('mutation 후 tagGroupsRaw가 재조회된다', () async {
+  group('TagGroupsRaw - 캐시 갱신', () {
+    test('CUD 후 invalidateSelf로 목록이 재조회된다', () async {
       stubRead([]);
       when(
         () => api.deleteTagV1TagsTagIdDelete(
@@ -211,17 +277,73 @@ void main() {
         ),
       ).thenAnswer((_) async {});
 
-      final container = makeContainer();
-      // keepAlive: 무효화 후 재계산을 관찰하기 위해 구독 유지
-      container.listen(tagGroupsRawProvider, (_, _) {});
-
-      await container.read(tagGroupsRawProvider.future);
-      await container.read(tagMutationsProvider.notifier).deleteTag('t1');
-      await container.read(tagGroupsRawProvider.future);
+      final container = listeningContainer();
+      await container.read(tagGroupsRawProvider.future); // 최초 조회
+      await container.read(tagGroupsRawProvider.notifier).deleteTag('t1');
+      await container.read(tagGroupsRawProvider.future); // 갱신 후 재조회
 
       verify(
         () => api.readTagGroupsV1TagsGroupsGet(options: any(named: 'options')),
       ).called(2);
+    });
+  });
+
+  group('Mutation - UI operation state', () {
+    test('run 성공 시 상태가 MutationSuccess가 되고 목록이 갱신된다', () async {
+      stubRead([]);
+      when(
+        () => api.deleteTagGroupV1TagsGroupsGroupIdDelete(
+          groupId: any(named: 'groupId'),
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer((_) async {});
+
+      final container = listeningContainer();
+      container.listen(deleteTagGroupMutation, (_, _) {}); // 상태 구독(자동 reset 방지)
+      await container.read(tagGroupsRawProvider.future); // 최초 조회
+
+      await deleteTagGroupMutation.run(
+        container,
+        (tsx) => tsx.get(tagGroupsRawProvider.notifier).deleteGroup('g1'),
+      );
+
+      expect(container.read(deleteTagGroupMutation).isSuccess, isTrue);
+      verify(
+        () => api.deleteTagGroupV1TagsGroupsGroupIdDelete(
+          groupId: 'g1',
+          options: any(named: 'options'),
+        ),
+      ).called(1);
+      // invalidateSelf로 목록이 재조회됨
+      await container.read(tagGroupsRawProvider.future);
+      verify(
+        () => api.readTagGroupsV1TagsGroupsGet(options: any(named: 'options')),
+      ).called(2);
+    });
+
+    test('run 실패 시 원래 에러를 rethrow하고 상태가 MutationError가 된다', () async {
+      stubRead([]);
+      when(
+        () => api.deleteTagGroupV1TagsGroupsGroupIdDelete(
+          groupId: any(named: 'groupId'),
+          options: any(named: 'options'),
+        ),
+      ).thenThrow(Exception('delete-failed'));
+
+      final container = listeningContainer();
+      container.listen(deleteTagGroupMutation, (_, _) {});
+
+      await expectLater(
+        deleteTagGroupMutation.run(
+          container,
+          (tsx) => tsx.get(tagGroupsRawProvider.notifier).deleteGroup('g1'),
+        ),
+        throwsA(
+          predicate((Object? e) => e.toString().contains('delete-failed')),
+        ),
+      );
+
+      expect(container.read(deleteTagGroupMutation).hasError, isTrue);
     });
   });
 }


### PR DESCRIPTION
## Change Log

**#66 — async mutation의 dispose 이후 ref 접근(UnmountedRefException) 방지**

문제의 본질은 "삭제"가 아니라 **async gap(await) 이후의 lifecycle safety**다.
mutation provider는 network side-effect와 UI state를 동시에 들고 있지만 provider
생명주기는 UI 구독에 묶여 있어, `await` 도중 화면 이탈·scope teardown으로 dispose되면
이후 `ref.invalidate`/`state` 접근이 `Cannot use the Ref ... after it has been disposed`
(UnmountedRefException)로 터진다. 실제로는 성공한 삭제가 이 에러 전파로 "실패"
SnackBar로 보이던 현상의 원인이기도 하다.

- 모든 async mutation에 동일 패턴 적용
  - dependency는 `await` 전에 `ref.read`로 확보
  - `await` 이후 `ref.invalidate`/`state`는 `if (ref.mounted)` 블록 안에서만
  - `catch`의 `state = error`도 `ref.mounted` 확인 뒤에만, 원래 에러는 그대로 전파
- 적용 도메인 (mutation notifier 전수)
  - `TagMutations`: createGroup·updateGroup·deleteGroup·createTag·updateTag·deleteTag
  - `ScheduleMutations`: createSchedule·updateSchedule·deleteSchedule·convertToTodo
    (기존 early-return/leading-guard 혼재 → 동일 블록 패턴으로 통일)
  - `TodoMutationsNotifier`: create·update·delete (delete는 bool 계약 유지)

**전 도메인 조사 결과**
- 추가 위험 지점 없음: `TimerController`는 `await` 없이 WS 동기 전송(async gap 자체가 없음),
  `AuthNotifier`는 keepAlive이며 await 이후 state/ref를 만지지 않음(상태는 리스너가 갱신)
- 중복 mutation provider 없음(각 1개). feature별 tag provider 중복은 #62(#68)에서 이미 제거 →
  "같은 역할 provider가 여러 위치"라는 재발 구조는 닫힌 상태

**테스트 (test-centric 검증)**
- `test/shared/providers/mutation_dispose_safety_test.dart`를 "삭제"가 아니라
  "async gap 이후 dispose 안전성" 정책 테스트로 재정의
- 13개 메서드 × (성공 직전 dispose / 실패 직전 dispose) = **26 케이스**
- 가드 제거 시 동일 케이스가 disposed-ref 에러로 red임을 확인(성공·실패 경로 모두)
- 전체 **404 통과**, `fvm flutter analyze` 통과

**근거 (Riverpod 3)**
- `ref.mounted`가 이 문제의 공식 해법(2.x엔 없던 API). rebuild 시 구독은 dispose가 아니라
  pause되어 남은 노출 지점은 scope/container teardown뿐이며 이를 `ref.mounted`로 방어한다.
- 더 근본적 대안인 experimental Mutation API는 호출부·테스트 전면 개편이 필요해 미채택.

## Issue Number
- close #66

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] Code generation runs cleanly (`fvm dart run build_runner build --delete-conflicting-outputs`)
- [x] `fvm flutter analyze` passes with no issues.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new widget, screen, or provider).
- [ ] This PR is a breaking change (e.g. model or API client changes).
