### PR TITLE
docs: Mutation 전환 changelog 반영 (#66 후속)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
+### Changed
+
+#### Todo & Schedule Mutations
+- Todo·Schedule CUD 흐름을 Riverpod `Mutation` API 기반 command 패턴으로 전환
+  - 기존 mutation notifier의 `AsyncValue` 로딩/성공/실패 상태 관리를 제거하고, REST 호출 및 관련 provider invalidation 책임만 유지
+  - `mutation.run(..., (tsx) => tsx.get(...notifier).xxx())` 호출 패턴으로 통일해 작업 중 provider 생존과 완료 후 캐시 갱신을 보장
+  - Todo 생성/수정/삭제/상태변경/부모변경, Schedule 생성/수정/삭제/이동/리사이즈/TODO 변환 호출부를 새 패턴으로 전환
+- Todo 삭제 실패 처리를 bool 반환 대신 원래 예외를 전파하는 방식으로 통일
+
+### Added
+
+#### Tests
+- Todo·Schedule mutation 도메인별 테스트 추가
+  - CUD REST API 호출 검증
+  - provider invalidation 후 재조회 검증
+  - `Mutation` 성공/실패 상태 및 원래 예외 전파 검증
+
+### Removed
+
+#### Tests
+- ref.mounted 가드 기반 공용 dispose 안전성 테스트 제거
+  - Mutation 기반 도메인 테스트로 검증 범위 대체
 
 ---
 


### PR DESCRIPTION
## Change Log

**#66 후속 — todo·schedule Mutation 전환 내역을 CHANGELOG에 반영**

PR #74로 `dev`에 병합된 todo·schedule CUD의 Riverpod Mutation API 전환 내용을 `CHANGELOG.md`의 `[Unreleased]` 항목에 정리한다.

- **문서**
  - Todo·Schedule CUD 흐름의 Riverpod `Mutation` API 기반 command 패턴 전환 내용을 `Changed` 항목에 기록.
  - 기존 mutation notifier의 `AsyncValue` 상태 관리 제거, `mutation.run(...tsx.get...)` 호출 패턴 통일, 작업 중 provider 생존 및 완료 후 캐시 갱신 보장 내용을 명시.
  - Todo 삭제 실패 계약 변경(bool 반환 → 원래 예외 전파)을 changelog에 반영.
- **테스트 기록**
  - Todo·Schedule mutation 도메인별 테스트 추가 내용을 `Added` 항목에 기록.
  - 기존 ref.mounted 가드 기반 공용 dispose 안전성 테스트 제거 및 Mutation 기반 도메인 테스트 대체 내용을 `Removed` 항목에 기록.
- **범위**
  - 코드 변경 없음. PR #74 병합 내용에 대한 changelog 보강만 포함.

**테스트**
- 문서 변경만 포함하므로 추가 테스트는 실행하지 않음.
- 기준 변경 검증은 PR #74에서 완료: 전체 테스트 통과, `fvm flutter analyze` 통과, 로컬 `flutter build web --wasm --release` 빌드 성공.

## Issue Number
- refs #66

## Checklist

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [x] Code generation runs cleanly (`fvm dart run build_runner build --delete-conflicting-outputs`) — 문서 변경만 포함, 생성 코드 변경 없음.
- [x] `fvm flutter analyze` passes with no issues. — 문서 변경만 포함, 기준 변경은 PR #74에서 검증 완료.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new widget, screen, or provider).
- [ ] This PR is a breaking change (e.g. model or API client changes).
