### PR TITLE
fix: 만료 토큰 잔존 시 빈 랜딩 페이지 도달 버그 수정 (#64)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -203,10 +203,20 @@
           return k.startsWith('sb-') && k.endsWith('-auth-token');
         });
       }
+      // 명시적 /landing 은 항상 랜딩으로 표시한다.
+      //   Flutter 라우터가 미인증을 확정하고 /landing 으로 보낸 신호이므로,
+      //   만료된 토큰 키가 localStorage 에 남아 있어도(= hasSupabaseSession() true)
+      //   랜딩을 보여줘야 한다. 그렇지 않으면 토글이 동작하지 않아 빈 화면에 도달한다. (#64)
+      function isExplicitLandingHash(hash) {
+        return hash === '#/landing' || hash === '#/landing/';
+      }
+      // 루트(''·#/)는 Flutter 부팅 전 첫 페인트 최적화 — 세션 키가 없을 때만 랜딩.
+      function isRootHash(hash) {
+        return hash === '' || hash === '#/';
+      }
       function isLandingHash(hash) {
-        var isLandingRoute = hash === '#/landing' || hash === '#/landing/'
-            || hash === '' || hash === '#/';
-        return isLandingRoute && !hasSupabaseSession();
+        return isExplicitLandingHash(hash)
+            || (isRootHash(hash) && !hasSupabaseSession());
       }
       window.__momeet = {
         isLanding: isLandingHash(window.location.hash),


### PR DESCRIPTION
## Change Log

**#64 — 만료된 토큰 처리 시 빈 랜딩 페이지**
- 만료 토큰으로 재접속하면 Flutter가 401 → `signOut` 후 `/landing`으로 리다이렉트하지만, 정적 랜딩 토글(`web/landing/script.js`)이 동작하지 않아 빈 화면에 도달하던 문제 수정.
- **원인**: 랜딩 표시 판정 `isLandingHash`가 `hasSupabaseSession()`(= `sb-*-auth-token` 키의 *존재 여부*)에만 의존. 만료 토큰 키가 localStorage에 남아 있으면 Flutter가 `/landing`으로 라우팅해도 `isLandingHash`가 false를 반환 → `showLanding()` 미호출. Flutter의 `/landing` 라우트는 `SizedBox.shrink()`라 화면이 비어 버림.
- **해결**: 명시적 `#/landing`(및 trailing slash)은 Flutter 라우터가 미인증을 확정하고 보낸 신호이므로, 세션 키 잔존 여부와 무관하게 항상 랜딩을 표시. 루트(`''`·`#/`)는 부팅 전 첫 페인트 최적화로 세션 키가 없을 때만 랜딩.
- 변경 범위: `web/index.html` 1개 (Dart 코드 변경 없음).

## Issue Number
- close #64

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] Code generation runs cleanly (`fvm dart run build_runner build --delete-conflicting-outputs`) — N/A (web/index.html만 변경)
- [x] `fvm flutter analyze` passes with no issues. — N/A (Dart 변경 없음)
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new widget, screen, or provider).
- [ ] This PR is a breaking change (e.g. model or API client changes).

> 검증: 이 레포에 JS 테스트 하네스가 없어 라우트 판정 함수(`isLandingHash`)의 진리표를 node로 검증 — 버그 시나리오(`#/landing` + 만료 토큰 키 잔존) 포함 전 케이스 통과, 인증 사용자 루트 진입 등 기존 동작 회귀 없음.