### PR TITLE
feat: 로그인↔회원가입 폼 전환 시 이메일 이어받기

### DIFF
--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -8,7 +8,13 @@ import 'package:momeet/features/auth/presentation/widgets/auth_text_field.dart';
 import 'package:momeet/shared/widgets/error_banner.dart';
 
 class LoginPage extends ConsumerStatefulWidget {
-  const LoginPage({super.key});
+  const LoginPage({super.key, this.initialEmail});
+
+  /// 회원가입 폼에서 전환해 올 때 이어받는 이메일.
+  ///
+  /// URL이 아닌 라우터 `extra`(인메모리)로 전달돼 재입력 부담을 줄입니다.
+  /// 비밀번호는 보안상 이어받지 않습니다.
+  final String? initialEmail;
 
   @override
   ConsumerState<LoginPage> createState() => _LoginPageState();
@@ -25,6 +31,7 @@ class _LoginPageState extends ConsumerState<LoginPage> {
   @override
   void initState() {
     super.initState();
+    _emailController.text = widget.initialEmail ?? '';
     _emailController.addListener(_clearError);
     _passwordController.addListener(_clearError);
   }
@@ -177,7 +184,10 @@ class _LoginPageState extends ConsumerState<LoginPage> {
                 children: [
                   const Text('계정이 없으신가요?'),
                   TextButton(
-                    onPressed: () => context.push(AppRoute.signup.path),
+                    onPressed: () => context.push(
+                      AppRoute.signup.path,
+                      extra: _emailController.text.trim(),
+                    ),
                     child: const Text('회원가입'),
                   ),
                 ],

--- a/lib/features/auth/presentation/pages/signup_page.dart
+++ b/lib/features/auth/presentation/pages/signup_page.dart
@@ -7,7 +7,13 @@ import 'package:momeet/features/auth/presentation/widgets/auth_button.dart';
 import 'package:momeet/features/auth/presentation/widgets/auth_text_field.dart';
 
 class SignupPage extends ConsumerStatefulWidget {
-  const SignupPage({super.key});
+  const SignupPage({super.key, this.initialEmail});
+
+  /// 로그인 폼에서 전환해 올 때 이어받는 이메일.
+  ///
+  /// URL이 아닌 라우터 `extra`(인메모리)로 전달돼 재입력 부담을 줄입니다.
+  /// 비밀번호는 보안상 이어받지 않습니다.
+  final String? initialEmail;
 
   @override
   ConsumerState<SignupPage> createState() => _SignupPageState();
@@ -21,6 +27,12 @@ class _SignupPageState extends ConsumerState<SignupPage> {
   bool _isLoading = false;
   bool _obscurePassword = true;
   bool _obscureConfirmPassword = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _emailController.text = widget.initialEmail ?? '';
+  }
 
   @override
   void dispose() {
@@ -57,7 +69,10 @@ class _SignupPageState extends ConsumerState<SignupPage> {
               TextButton(
                 onPressed: () {
                   Navigator.of(context).pop();
-                  context.go(AppRoute.login.path);
+                  context.go(
+                    AppRoute.login.path,
+                    extra: _emailController.text.trim(),
+                  );
                 },
                 child: const Text('확인'),
               ),
@@ -207,7 +222,10 @@ class _SignupPageState extends ConsumerState<SignupPage> {
                 children: [
                   const Text('이미 계정이 있으신가요?'),
                   TextButton(
-                    onPressed: () => context.go('/login'),
+                    onPressed: () => context.go(
+                      AppRoute.login.path,
+                      extra: _emailController.text.trim(),
+                    ),
                     child: const Text('로그인'),
                   ),
                 ],

--- a/lib/router.dart
+++ b/lib/router.dart
@@ -197,13 +197,19 @@ final routerProvider = Provider<GoRouter>((ref) {
       GoRoute(
         path: AppRoute.login.path,
         name: AppRoute.login.name,
-        builder: (context, state) => const LoginPage(),
+        // extra: 로그인↔회원가입 폼 전환 시 이어받는 이메일(인메모리)
+        builder: (context, state) => LoginPage(
+          initialEmail: state.extra is String ? state.extra as String : null,
+        ),
       ),
 
       GoRoute(
         path: AppRoute.signup.path,
         name: AppRoute.signup.name,
-        builder: (context, state) => const SignupPage(),
+        // extra: 로그인↔회원가입 폼 전환 시 이어받는 이메일(인메모리)
+        builder: (context, state) => SignupPage(
+          initialEmail: state.extra is String ? state.extra as String : null,
+        ),
       ),
 
       GoRoute(

--- a/test/features/auth/presentation/pages/login_page_test.dart
+++ b/test/features/auth/presentation/pages/login_page_test.dart
@@ -174,4 +174,50 @@ void main() {
       expect(find.text('비밀번호를 입력해주세요'), findsOneWidget);
     });
   });
+
+  // ============================================================
+  // 폼 전환 시 이메일 이어받기 (initialEmail)
+  // ============================================================
+  group('이메일 이어받기 (initialEmail)', () {
+    String fieldText(WidgetTester tester, int index) => tester
+        .widget<EditableText>(find.byType(EditableText).at(index))
+        .controller
+        .text;
+
+    testWidgets('initialEmail이 주어지면 이메일 필드에 채워진다', (tester) async {
+      await tester.pumpWidget(
+        pumpApp(
+          const LoginPage(initialEmail: 'carry@over.com'),
+          overrides: [
+            supabaseClientProvider.overrideWithValue(harness.mockSupabase),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('carry@over.com'), findsOneWidget);
+      expect(fieldText(tester, 0), 'carry@over.com');
+    });
+
+    testWidgets('비밀번호는 이어받지 않아 비어 있다', (tester) async {
+      await tester.pumpWidget(
+        pumpApp(
+          const LoginPage(initialEmail: 'carry@over.com'),
+          overrides: [
+            supabaseClientProvider.overrideWithValue(harness.mockSupabase),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(fieldText(tester, 1), '');
+    });
+
+    testWidgets('initialEmail이 없으면 이메일 필드가 비어 있다', (tester) async {
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      expect(fieldText(tester, 0), '');
+    });
+  });
 }

--- a/test/features/auth/presentation/pages/login_page_test.dart
+++ b/test/features/auth/presentation/pages/login_page_test.dart
@@ -3,8 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:momeet/core/providers/auth_provider.dart';
 import 'package:momeet/features/auth/presentation/pages/login_page.dart';
+import 'package:momeet/features/auth/presentation/pages/signup_page.dart';
 import 'package:supabase_flutter/supabase_flutter.dart' as supa;
 
+import '../../../../helpers/auth_router.dart';
 import '../../../../helpers/pump_app.dart';
 import '../../../../helpers/supabase_mocks.dart';
 
@@ -199,10 +201,17 @@ void main() {
       expect(fieldText(tester, 0), 'carry@over.com');
     });
 
-    testWidgets('비밀번호는 이어받지 않아 비어 있다', (tester) async {
+    testWidgets('initialEmail이 없으면 이메일 필드가 비어 있다', (tester) async {
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      expect(fieldText(tester, 0), '');
+    });
+
+    testWidgets('로그인 → 회원가입 전환 시 이메일만 넘어가고 비밀번호는 안 넘어간다', (tester) async {
       await tester.pumpWidget(
-        pumpApp(
-          const LoginPage(initialEmail: 'carry@over.com'),
+        pumpAuthFlow(
+          initialLocation: '/login',
           overrides: [
             supabaseClientProvider.overrideWithValue(harness.mockSupabase),
           ],
@@ -210,14 +219,32 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      expect(fieldText(tester, 1), '');
-    });
-
-    testWidgets('initialEmail이 없으면 이메일 필드가 비어 있다', (tester) async {
-      await tester.pumpWidget(buildLoginPage());
+      // 로그인 폼에 이메일 + 비밀번호를 모두 입력
+      await tester.enterText(find.byType(EditableText).at(0), 'carry@over.com');
+      await tester.enterText(find.byType(EditableText).at(1), 'secret-pw');
       await tester.pumpAndSettle();
 
-      expect(fieldText(tester, 0), '');
+      // "회원가입" 전환 버튼 → 회원가입 폼으로 이동
+      await tester.tap(find.widgetWithText(TextButton, '회원가입'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SignupPage), findsOneWidget);
+
+      String signupField(int index) => tester
+          .widget<EditableText>(
+            find
+                .descendant(
+                  of: find.byType(SignupPage),
+                  matching: find.byType(EditableText),
+                )
+                .at(index),
+          )
+          .controller
+          .text;
+
+      expect(signupField(0), 'carry@over.com'); // 이메일 이어받음
+      expect(signupField(1), ''); // 비밀번호는 전달 안 됨
+      expect(signupField(2), ''); // 비밀번호 확인도 전달 안 됨
     });
   });
 }

--- a/test/features/auth/presentation/pages/signup_page_test.dart
+++ b/test/features/auth/presentation/pages/signup_page_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:momeet/core/providers/auth_provider.dart';
+import 'package:momeet/features/auth/presentation/pages/signup_page.dart';
+
+import '../../../../helpers/pump_app.dart';
+import '../../../../helpers/supabase_mocks.dart';
+
+void main() {
+  late SupabaseTestHarness harness;
+
+  setUp(() {
+    harness = SupabaseTestHarness()..init(authenticated: false);
+  });
+
+  tearDown(() {
+    harness.dispose();
+  });
+
+  Widget buildSignupPage({String? initialEmail}) {
+    return pumpApp(
+      SignupPage(initialEmail: initialEmail),
+      overrides: [
+        supabaseClientProvider.overrideWithValue(harness.mockSupabase),
+      ],
+    );
+  }
+
+  String fieldText(WidgetTester tester, int index) => tester
+      .widget<EditableText>(find.byType(EditableText).at(index))
+      .controller
+      .text;
+
+  // ============================================================
+  // 폼 전환 시 이메일 이어받기 (initialEmail)
+  // ============================================================
+  group('이메일 이어받기 (initialEmail)', () {
+    testWidgets('initialEmail이 주어지면 이메일 필드에 채워진다', (tester) async {
+      await tester.pumpWidget(buildSignupPage(initialEmail: 'carry@over.com'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('carry@over.com'), findsOneWidget);
+      expect(fieldText(tester, 0), 'carry@over.com');
+    });
+
+    testWidgets('비밀번호·비밀번호 확인 필드는 이어받지 않아 비어 있다', (tester) async {
+      await tester.pumpWidget(buildSignupPage(initialEmail: 'carry@over.com'));
+      await tester.pumpAndSettle();
+
+      expect(fieldText(tester, 1), '');
+      expect(fieldText(tester, 2), '');
+    });
+
+    testWidgets('initialEmail이 없으면 이메일 필드가 비어 있다', (tester) async {
+      await tester.pumpWidget(buildSignupPage());
+      await tester.pumpAndSettle();
+
+      expect(fieldText(tester, 0), '');
+    });
+  });
+}

--- a/test/features/auth/presentation/pages/signup_page_test.dart
+++ b/test/features/auth/presentation/pages/signup_page_test.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:momeet/core/providers/auth_provider.dart';
+import 'package:momeet/features/auth/presentation/pages/login_page.dart';
 import 'package:momeet/features/auth/presentation/pages/signup_page.dart';
 
+import '../../../../helpers/auth_router.dart';
 import '../../../../helpers/pump_app.dart';
 import '../../../../helpers/supabase_mocks.dart';
 
@@ -43,19 +45,50 @@ void main() {
       expect(fieldText(tester, 0), 'carry@over.com');
     });
 
-    testWidgets('비밀번호·비밀번호 확인 필드는 이어받지 않아 비어 있다', (tester) async {
-      await tester.pumpWidget(buildSignupPage(initialEmail: 'carry@over.com'));
-      await tester.pumpAndSettle();
-
-      expect(fieldText(tester, 1), '');
-      expect(fieldText(tester, 2), '');
-    });
-
     testWidgets('initialEmail이 없으면 이메일 필드가 비어 있다', (tester) async {
       await tester.pumpWidget(buildSignupPage());
       await tester.pumpAndSettle();
 
       expect(fieldText(tester, 0), '');
+    });
+
+    testWidgets('회원가입 → 로그인 전환 시 이메일만 넘어가고 비밀번호는 안 넘어간다', (tester) async {
+      await tester.pumpWidget(
+        pumpAuthFlow(
+          initialLocation: '/signup',
+          overrides: [
+            supabaseClientProvider.overrideWithValue(harness.mockSupabase),
+          ],
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // 회원가입 폼에 이메일 + 비밀번호 + 비밀번호 확인을 모두 입력
+      await tester.enterText(find.byType(EditableText).at(0), 'carry@over.com');
+      await tester.enterText(find.byType(EditableText).at(1), 'secret-pw');
+      await tester.enterText(find.byType(EditableText).at(2), 'secret-pw');
+      await tester.pumpAndSettle();
+
+      // "로그인" 전환 버튼 → 로그인 폼으로 이동
+      await tester.tap(find.widgetWithText(TextButton, '로그인'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(LoginPage), findsOneWidget);
+
+      String loginField(int index) => tester
+          .widget<EditableText>(
+            find
+                .descendant(
+                  of: find.byType(LoginPage),
+                  matching: find.byType(EditableText),
+                )
+                .at(index),
+          )
+          .controller
+          .text;
+
+      expect(loginField(0), 'carry@over.com'); // 이메일 이어받음
+      expect(loginField(1), ''); // 비밀번호는 전달 안 됨
     });
   });
 }

--- a/test/helpers/auth_router.dart
+++ b/test/helpers/auth_router.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:go_router/go_router.dart';
+import 'package:momeet/features/auth/presentation/pages/login_page.dart';
+import 'package:momeet/features/auth/presentation/pages/signup_page.dart';
+
+/// 로그인↔회원가입 전환(`extra`로 이메일 전달)을 end-to-end로 검증하기 위한
+/// 최소 라우터 + MaterialApp.router.
+///
+/// `lib/router.dart`의 login/signup 빌더 와이어링(`state.extra` 주입)을
+/// 그대로 미러링하므로, 실제 전환 버튼 → extra 전달 → initState 프리필
+/// 경로를 통째로 태울 수 있습니다.
+Widget pumpAuthFlow({
+  required String initialLocation,
+  List<Override> overrides = const [],
+}) {
+  final router = GoRouter(
+    initialLocation: initialLocation,
+    routes: [
+      GoRoute(
+        path: '/login',
+        builder: (context, state) => LoginPage(
+          initialEmail: state.extra is String ? state.extra as String : null,
+        ),
+      ),
+      GoRoute(
+        path: '/signup',
+        builder: (context, state) => SignupPage(
+          initialEmail: state.extra is String ? state.extra as String : null,
+        ),
+      ),
+    ],
+  );
+
+  return ProviderScope(
+    overrides: overrides,
+    child: MaterialApp.router(routerConfig: router),
+  );
+}


### PR DESCRIPTION
## Change Log

**로그인↔회원가입 폼 전환 시 입력한 이메일 이어받기**
- 폼 전환 버튼으로 이동할 때 입력한 이메일을 이어받아 재입력 부담을 줄입니다(NN/g 휴리스틱: Error Prevention / Recognition rather than recall).
- 비밀번호는 보안상 이어받지 않습니다. 이메일은 URL이 아닌 라우터 `extra`(인메모리)로 전달해 브라우저 히스토리·로그 노출을 피합니다.
- 적용 지점(모두 이메일 전달):
  - 로그인 → 회원가입 ("회원가입" 버튼)
  - 회원가입 → 로그인 ("로그인" 버튼)
  - 회원가입 성공 다이얼로그 "확인" → 로그인
- 구현:
  - `LoginPage`·`SignupPage`에 `initialEmail` 파라미터 추가, `initState`에서 프리필
  - 라우터 `login`/`signup` 빌더에서 `state.extra`(String) 주입 — 타입가드로 잘못된/없는 extra는 안전하게 무시

## Issue Number
- N/A (추적 이슈 없음)

## Checklist

- [x] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [x] Code generation runs cleanly (`fvm dart run build_runner build --delete-conflicting-outputs`)
- [x] `fvm flutter analyze` passes with no issues.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new widget, screen, or provider).
- [ ] This PR is a breaking change (e.g. model or API client changes).

> 검증: 프리필 동작 + 비밀번호 미전달 회귀 테스트 추가(login·signup). 전체 401 테스트 통과, `flutter analyze`·`custom_lint` 무이슈.